### PR TITLE
Crawlera integration and splash exit proxy support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.txt
 include *.rst
 include tox.ini
+include scrapyjs/crawlera.lua
 recursive-include tests *.py
 recursive-include example *.py *.cfg

--- a/README.rst
+++ b/README.rst
@@ -246,6 +246,31 @@ Run a simple `Splash Lua Script`_::
 
 .. _Splash Lua Script: http://splash.readthedocs.org/en/latest/scripting-tutorial.html
 
+Proxies
+=======
+
+When a proxy is set in a request (via ``request.meta["proxy"]``) before the
+request it's processed by the middleware, the value it's moved to the ``proxy``
+splash argument and removed from the request, so that splash will use that
+proxy to connect to the page.
+
+To set the proxy that needs to be used to connect to splash, set the
+``request.meta["proxy"]`` in a middleware configured to run after
+SplashMiddleware. Note that by default the proxy middleware is enabled and will
+run after SplashMiddleware, so by default it will use your configured system
+proxy or the ``HTTP_PROXY`` environment variable to connect to splash.
+
+When using this SplashMiddleware with Crawlera_ as a proxy, it will rewrite the
+arguments to use the ``/execute`` endpoint and send a `lua script`_ that creates a
+`Crawlera session`_ and uses it to load the page's sub-resources. The
+script is mostly compatible with splash's ``render.html`` endpoint, but only a
+subset of the options are available: ``filters``, ``timeout``,
+``allowed_domains``, ``headers``, ``baseurl``, ``viewport``, ``wait`` and
+``js_source``.
+
+.. _lua script: https://github.com/scrapinghub/scrapyjs/blob/master/scrapyjs/crawlera.lua
+.. _Crawlera: http://scrapinghub.com/crawlera/
+.. _Crawlera session: http://doc.scrapinghub.com/crawlera.html#x-crawlera-session
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -265,7 +265,7 @@ arguments to use the ``/execute`` endpoint and send a `lua script`_ that creates
 `Crawlera session`_ and uses it to load the page's sub-resources. The
 script is mostly compatible with splash's ``render.html`` endpoint, but only a
 subset of the options are available: ``filters``, ``timeout``,
-``allowed_domains``, ``headers``, ``baseurl``, ``viewport``, ``wait`` and
+``allowed_domains``, ``headers``, ``baseurl``, ``viewport``, ``wait``, ``images`` and
 ``js_source``.
 
 .. _lua script: https://github.com/scrapinghub/scrapyjs/blob/master/scrapyjs/crawlera.lua

--- a/scrapyjs/crawlera.lua
+++ b/scrapyjs/crawlera.lua
@@ -1,0 +1,79 @@
+
+function parse_viewport(viewport)
+    -- Splash lua has no regex support, if added, /\d+x\d+/
+    local sep = viewport:find("x")
+    if sep then
+        width = tonumber(viewport:sub(1, sep-1))
+        height = tonumber(viewport:sub(sep+1, #viewport))
+        if width and height then
+            return {width, height}
+        end
+    end
+    return nil
+end
+
+function main(splash)
+    local args = splash.args
+    local crawlera = args.crawlera or {}
+    local host = crawlera.host or 'proxy.crawlera.com'
+    local port = crawlera.port or 8010
+    local subrequest_headers = crawlera.subrequest_headers or {}
+    local allrequest_headers = crawlera.headers or {}
+    local firstrequest_headers = args.headers or {}
+
+    local session_header = "X-Crawlera-Session"
+    local session_id = "create"
+
+    splash:on_request(function (request)
+        if session_id ~= 'create' then
+            -- Set subresource request headers
+            for key,value in pairs(subrequest_headers) do
+                request:set_header(name, value)
+            end
+        end
+        for key,value in pairs(allrequest_headers) do
+            request:set_header(name, value)
+        end
+
+        -- Implement resource_timeout parameter like in render.html
+        if type(args.resource_timeout) == 'number' then
+            request:set_timeout(args.resource_timeout)
+        end
+
+        request:set_header(session_header, session_id)
+        request:set_proxy{host, port, username=crawlera.user, password=crawlera.pass}
+    end)
+
+    splash:on_response_headers(function (response)
+        if type(response.headers[session_header]) ~= nil then
+            session_id = response.headers[session_header]
+        end
+    end)
+
+    -- Implement some of the arguments to render.html
+
+    splash:set_custom_headers(firstrequest_headers)
+
+    if type(args.viewport) == 'string' then
+        local width, height = parse_viewport(args.viewport)
+        if width and height then
+            splash:set_viewport_size(width, height)
+        end
+    end
+
+    assert(splash:go{args.url, baseurl=args.baseurl, headers=args.headers})
+
+    if args.viewport == 'full' or args.render_all then
+        splash:set_viewport_full()
+    end
+
+    if type(args.wait) == 'number' then
+        splash:wait(args.wait)
+    end
+
+    if type(args.js_source) == 'string' then
+        splash:runjs(args.js_source)
+    end
+
+    return splash:html()
+end

--- a/scrapyjs/crawlera.lua
+++ b/scrapyjs/crawlera.lua
@@ -107,6 +107,10 @@ function main(splash)
         splash:set_viewport_full()
     end
 
+    if args.images ~= nil then
+        splash.images_enabled = args.images
+    end
+
     if type(args.wait) == 'number' then
         splash:wait(args.wait)
     end

--- a/scrapyjs/crawlera.lua
+++ b/scrapyjs/crawlera.lua
@@ -50,6 +50,10 @@ function main(splash)
     local session_header = "X-Crawlera-Session"
     local session_id = "create"
 
+    if splash.on_response_headers == nil then
+        error("Splash 1.7 is required for Crawlera integration")
+    end
+
     splash:on_request(function (request)
         if session_id ~= 'create' then
             -- Set subresource request headers

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -176,7 +176,6 @@ class SplashMiddleware(object):
             'js': (None, ''),
             'allowed_content_types': (None, ''),
             'forbidden_content_types': (None, ''),
-            'images': (True, 1),
         }
         for option, allowed in not_implemented_options.items():
             if option in splash_args and splash_args[option] not in allowed:

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    package_data={'': ['scrapyjs/crawlera.lua']},
+    include_package_data=True,
     requires=['scrapy'],
 )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -205,7 +205,7 @@ def test_crawlera_not_supported():
         "proxy": 'subdomain.crawlera.com:1234',
         "splash": {
             "args": {
-                "images": 0,
+                "js": "js_profile_foo",
             }
         }
     })


### PR DESCRIPTION
Needs splash 1.7 in the server or greater in the server for Crawlera integration and the next release of splash (with this PR  https://github.com/scrapinghub/splash/pull/280) to set the splash exit proxy to something other than Crawlera (Issue #23)
