### PR TITLE
Python 3 compatibility

### DIFF
--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -2,7 +2,10 @@
 from __future__ import absolute_import
 import json
 import logging
-from urlparse import urljoin
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 
 from scrapy.exceptions import NotConfigured
 from scrapy.http.headers import Headers


### PR DESCRIPTION
Hi, just ran the library in a Python 3 context, this seems to be at least the main blocker for Python 3 compatibility, after fixing scraper went through. I also tested this with a couple of other own high-level unit tests.

Cheers
Holger
