### PR TITLE
Custom Splash responses

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 scrapyjs.egg-info
 .cache
 .coverage
+.scrapy

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ scrapyjs.egg-info
 .cache
 .coverage
 .scrapy
+htmlcov

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,9 @@ Configuration
 Usage
 =====
 
+Requests
+--------
+
 The easiest way to render requests with Splash is to
 use ``scrapyjs.SplashRequest``::
 
@@ -184,6 +187,28 @@ it should be easier to use in most cases.
      It is similar to ``SINGLE_SLOT`` policy, but can be different if you access
      other services on the same address as Splash.
 
+Responses
+---------
+
+ScrapyJS provides returns Response subclasses for Splash requests:
+
+* SplashResponse is returned for binary Splash responses - e.g. for
+  /render.png responses;
+* SplashTextResponse is returned when the result is text - e.g. for
+  /render.html responses;
+* SplashJsonResponse is returned when the result is a JSON object - e.g.
+  for /render.json responses or /execute responses when script returns
+  a Lua table.
+
+All these responses set ``response.url`` to the URL of the original request
+(i.e. to the URL of a website you want to render), not to the URL of the
+requested Splash endpoint. "True" URL is still available as
+``response.real_url``.
+
+SplashJsonResponse provide extra features:
+
+* ``response.data`` attribute contains response data decoded from JSON;
+  you can access it like ``response.data['html']``.
 
 Examples
 ========
@@ -373,7 +398,11 @@ aware of:
    in unexpected ways since delays and concurrency settings are no longer
    per-domain.
 
-3. Some options depend on each other - for example, if you use timeout_
+3. As seen by Scrapy, response.url is an URL of the Splash server.
+   scrapy-splash fixes it to be an URL of a requested page.
+   "Real" URL is still available as ``response.real_url``.
+
+4. Some options depend on each other - for example, if you use timeout_
    Splash option then you may want to set ``download_timeout``
    scrapy.Request meta key as well.
 

--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,12 @@ Configuration
       SPLASH_URL = 'http://192.168.59.103:8050'
 
 2. Enable the Splash middleware by adding it to ``DOWNLOADER_MIDDLEWARES``
-   in your ``settings.py`` file::
+   in your ``settings.py`` file and changing HttpCompressionMiddleware
+   priority::
 
       DOWNLOADER_MIDDLEWARES = {
           'scrapyjs.SplashMiddleware': 725,
+          'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 810,
       }
 
 .. note::
@@ -57,6 +59,10 @@ Configuration
    Order `725` is just before `HttpProxyMiddleware` (750) in default
    scrapy settings. `725` is also after ``CookiesMiddleware`` (700);
    this allows Scrapy to handle cookies.
+
+   HttpCompressionMiddleware priority should be changed inorder to allow
+   advanced response processing; see https://github.com/scrapy/scrapy/issues/1895
+   for details.
 
 3. Set a custom ``DUPEFILTER_CLASS``::
 

--- a/README.rst
+++ b/README.rst
@@ -376,7 +376,7 @@ sure to read the observations after it::
 
         def start_requests(self):
             for url in self.start_urls:
-                body = json.dumps({"url": url, "wait": 0.5})
+                body = json.dumps({"url": url, "wait": 0.5}, sort_keys=True)
                 headers = Headers({'Content-Type': 'application/json'})
                 yield scrapy.Request(RENDER_HTML_URL, self.parse, method="POST",
                                      body=body, headers=headers)
@@ -405,6 +405,12 @@ aware of:
 4. Some options depend on each other - for example, if you use timeout_
    Splash option then you may want to set ``download_timeout``
    scrapy.Request meta key as well.
+
+5. It is easy to get it subtely wrong - e.g. if you won't use
+   ``sort_keys=True`` argument when preparing JSON body then binary POST body
+   content could vary even if all keys and values are the same, and it means
+   dupefilter and cache will work incorrectly.
+
 
 ScrapyJS utlities allow to handle such edge cases and reduce the boilerplate.
 

--- a/README.rst
+++ b/README.rst
@@ -414,9 +414,9 @@ correct values::
       assert(splash:wait(0.5))
 
       return {
-        headers = last_response_headers(splash)
+        headers = last_response_headers(splash),
         cookies = splash:get_cookies(),
-        html = splash:html()
+        html = splash:html(),
       }
     end
     """

--- a/README.rst
+++ b/README.rst
@@ -406,7 +406,7 @@ aware of:
    Splash option then you may want to set ``download_timeout``
    scrapy.Request meta key as well.
 
-5. It is easy to get it subtely wrong - e.g. if you won't use
+5. It is easy to get it subtly wrong - e.g. if you won't use
    ``sort_keys=True`` argument when preparing JSON body then binary POST body
    content could vary even if all keys and values are the same, and it means
    dupefilter and cache will work incorrectly.

--- a/README.rst
+++ b/README.rst
@@ -239,6 +239,9 @@ SplashJsonResponse provide extra features:
 * ``response.data`` attribute contains response data decoded from JSON;
   you can access it like ``response.data['html']``.
 
+* If Splash session handling is configured, you can access current cookies
+  as ``response.cookiejar``; it is a CookieJar instance.
+
 * If Scrapy-Splash response magic is enabled in request (default),
   several response attributes (headers, body, url, status code)
   are set automatically from original response body:

--- a/README.rst
+++ b/README.rst
@@ -509,6 +509,11 @@ aware of:
    content could vary even if all keys and values are the same, and it means
    dupefilter and cache will work incorrectly.
 
+6. Splash Bad Request (HTTP 400) errors are hard to debug because by default
+   response content is not displayed by Scrapy. SplashMiddleware logs content
+   of HTTP 400 Splash responses by default (it can be turned off by setting
+   ``SPLASH_LOG_400 = False`` option).
+
 ScrapyJS utlities allow to handle such edge cases and reduce the boilerplate.
 
 .. _HTTP API: http://splash.readthedocs.org/en/latest/api.html

--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,7 @@ Alternatively, you can use regular scrapy.Request and
             'slot_policy': scrapyjs.SlotPolicy.PER_DOMAIN,
             'splash_headers': {},       # optional; a dict with headers sent to Splash
             'dont_process_response': True, # optional, default is False
+            'dont_send_headers': True,  # optional, default is False
             'magic_response': False,    # optional, default is True
         }
     })
@@ -202,6 +203,16 @@ it should be easier to use in most cases.
   SplashMiddleware won't change the response to a custom scrapy.Response
   subclass. By default for Splash requests one of SplashResponse,
   SplashTextResponse or SplashJsonResponse is passed to the callback.
+
+* ``meta['splash']['dont_send_headers']``: by default ScrapyJS passes
+  request headers to Splash in 'headers' JSON POST field. For all render.xxx
+  endpoints it means Scrapy header options are respected by default
+  (http://splash.readthedocs.org/en/stable/api.html#arg-headers). In Lua
+  scripts you can use ``headers`` argument of ``splash:go`` to apply the
+  passed headers: ``splash:go{url, headers=splash.args.headers}``.
+
+  Set 'dont_send_headers' to True if you don't want to pass ``headers``
+  to Splash.
 
 * ``meta['splash']['magic_response']`` - when set to True and a JSON
   response is received from Splash, several attributes of the response
@@ -462,7 +473,7 @@ correct values::
 
     function main(splash)
       splash:init_cookies(splash.args.cookies)
-      assert(splash:go(splash.args.url))
+      assert(splash:go{splash.args.url, headers=splash.args.headers})
       assert(splash:wait(0.5))
 
       return {
@@ -479,7 +490,8 @@ correct values::
         # ...
             yield SplashRequest(url, self.parse_result,
                 endpoint='execute',
-                args={'lua_source': script}
+                args={'lua_source': script},
+                headers={'X-My-Header': 'value'},
             )
 
         def parse_result(self, response):

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,7 @@ Alternatively, you can use regular scrapy.Request and
             'slot_policy': scrapyjs.SlotPolicy.PER_DOMAIN,
             'splash_headers': {},       # optional; a dict with headers sent to Splash
             'dont_process_response': True, # optional, default is False
+            'magic_response': False,    # optional, default is True
         }
     })
 
@@ -194,6 +195,16 @@ it should be easier to use in most cases.
   SplashMiddleware won't change the response to a custom scrapy.Response
   subclass. By default for Splash requests one of SplashResponse,
   SplashTextResponse or SplashJsonResponse is passed to the callback.
+
+* ``meta['splash']['magic_response']`` - when set to True and a JSON
+  response is received from Splash, several attributes of the response
+  (headers, body, url, status code) are filled using data returned in JSON:
+
+  * response.headers are filled from 'headers' and 'cookies' keys;
+  * response.url is set to the value of 'url' key;
+  * response.body is set to the value of 'html' key,
+    or to base64-decoded value of 'body' key;
+  * response.status is set to the value of 'http_status' key.
 
 Responses
 ---------

--- a/README.rst
+++ b/README.rst
@@ -305,6 +305,9 @@ set ``request.meta['splash']['args']['new_session_id']`` in addition to
 ``session_id``. Request cookies will be fetched from cookiejar ``session_id``,
 but response cookies will be merged back to the ``new_session_id`` cookiejar.
 
+Standard Scrapy ``cookies`` argument can be used with ``SplashRequest``
+to add cookies to the current Splash cookiejar.
+
 Examples
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Configuration
    scrapy settings. `725` is also after ``CookiesMiddleware`` (700);
    this allows Scrapy to handle cookies.
 
-   HttpCompressionMiddleware priority should be changed inorder to allow
+   HttpCompressionMiddleware priority should be changed in order to allow
    advanced response processing; see https://github.com/scrapy/scrapy/issues/1895
    for details.
 

--- a/README.rst
+++ b/README.rst
@@ -266,7 +266,7 @@ Session Handling
 Splash itself is stateless - each request starts from a clean state.
 In order to support sessions the following is required:
 
-1. client must send current cookies to Splash;
+1. client (Scrapy) must send current cookies to Splash;
 2. Splash script should make requests using these cookies and update
    them from HTTP response headers or JavaScript code;
 3. updated cookies should be sent back to the client;
@@ -280,14 +280,6 @@ in 'cookies' field and merge cookies back from 'cookies' response field
 set ``request.meta['splash']['args']['session_id']`` to the session
 identifier. If you only want a single session use the same ``session_id`` for
 all request; any value like '1' or 'foo' is fine.
-
-SplashRequest sets ``session_id`` automatically for ``/execute`` endpoint,
-i.e. cookie handling is enabled by default if you use SplashRequest.
-
-If you want to start from the same set of cookies, but then 'fork' sessions
-set ``request.meta['splash']['args']['new_session_id']`` in addition to
-``session_id``. Request cookies will be fetched from cookiejar ``session_id``,
-but response cookies will be merged back to the ``new_session_id`` cookiejar.
 
 For ScrapyJS session handling to work you must use ``/execute`` endpoint
 and a Lua script which accepts 'cookies' argument and returns 'cookies'
@@ -304,6 +296,14 @@ field in the result::
        }
    end
 
+SplashRequest sets ``session_id`` automatically for ``/execute`` endpoint,
+i.e. cookie handling is enabled by default if you use SplashRequest,
+``/execute`` endpoint and a compatible Lua rendering script.
+
+If you want to start from the same set of cookies, but then 'fork' sessions
+set ``request.meta['splash']['args']['new_session_id']`` in addition to
+``session_id``. Request cookies will be fetched from cookiejar ``session_id``,
+but response cookies will be merged back to the ``new_session_id`` cookiejar.
 
 Examples
 ========
@@ -562,6 +562,9 @@ aware of:
    response content is not displayed by Scrapy. SplashMiddleware logs content
    of HTTP 400 Splash responses by default (it can be turned off by setting
    ``SPLASH_LOG_400 = False`` option).
+
+7. Cookie handling is tedious to implement, and you can't use Scrapy
+   built-in Cookie middleware to handle cookies when working with Splash.
 
 ScrapyJS utlities allow to handle such edge cases and reduce the boilerplate.
 

--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,9 @@ it should be easier to use in most cases.
 
   Note that by default Scrapy escapes URL fragments using AJAX escaping scheme.
   If you want to pass a URL with a fragment to Splash then set ``url``
-  in ``args`` dict manually.
+  in ``args`` dict manually. This is handled automatically if you use
+  ``SplashRequest``, but you need to keep that in mind if you use raw
+  ``meta['splash']`` API.
 
   Splash 1.8+ is required to handle POST requests; in earlier Splash versions
   'http_method' and 'body' arguments are ignored. If you work with ``/execute``

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,7 @@ Alternatively, you can use regular scrapy.Request and
             'splash_url': '<url>',      # optional; overrides SPLASH_URL
             'slot_policy': scrapyjs.SlotPolicy.PER_DOMAIN,
             'splash_headers': {},       # optional; a dict with headers sent to Splash
+            'dont_process_response': True, # optional, default is False
         }
     })
 
@@ -188,6 +189,11 @@ it should be easier to use in most cases.
   3. ``scrapyjs.SlotPolicy.SCRAPY_DEFAULT`` - don't do anything with slots.
      It is similar to ``SINGLE_SLOT`` policy, but can be different if you access
      other services on the same address as Splash.
+
+* ``meta['splash']['dont_process_response']`` - when set to True,
+  SplashMiddleware won't change the response to a custom scrapy.Response
+  subclass. By default for Splash requests one of SplashResponse,
+  SplashTextResponse or SplashJsonResponse is passed to the callback.
 
 Responses
 ---------

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,8 @@ Configuration
 .. note::
 
    Order `725` is just before `HttpProxyMiddleware` (750) in default
-   scrapy settings.
+   scrapy settings. `725` is also after ``CookiesMiddleware`` (700);
+   this allows Scrapy to handle cookies.
 
 3. Set a custom ``DUPEFILTER_CLASS``::
 

--- a/example/scrashtest/settings.py
+++ b/example/scrashtest/settings.py
@@ -6,8 +6,11 @@ SPIDER_MODULES = ['scrashtest.spiders']
 NEWSPIDER_MODULE = 'scrashtest.spiders'
 
 DOWNLOADER_MIDDLEWARES = {
+    # Engine side
+    'scrapyjs.middleware.SplashCookiesMiddleware': 723,
     'scrapyjs.SplashMiddleware': 725,
     'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 810,
+    # Downloader side
 }
 
 DUPEFILTER_CLASS = 'scrapyjs.SplashAwareDupeFilter'

--- a/example/scrashtest/settings.py
+++ b/example/scrashtest/settings.py
@@ -7,6 +7,7 @@ NEWSPIDER_MODULE = 'scrashtest.spiders'
 
 DOWNLOADER_MIDDLEWARES = {
     'scrapyjs.SplashMiddleware': 725,
+    'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 810,
 }
 
 DUPEFILTER_CLASS = 'scrapyjs.SplashAwareDupeFilter'

--- a/example/scrashtest/spiders/dmoz.py
+++ b/example/scrashtest/spiders/dmoz.py
@@ -4,6 +4,8 @@ import json
 import scrapy
 from scrapy.linkextractors import LinkExtractor
 
+from scrapyjs import SplashRequest
+
 
 class DmozSpider(scrapy.Spider):
     name = "dmoz"
@@ -16,12 +18,18 @@ class DmozSpider(scrapy.Spider):
     def parse(self, response):
         le = LinkExtractor()
         for link in le.extract_links(response):
-            yield scrapy.Request(link.url, self.parse_link, meta={
-                'splash': {
-                    'args': {'har': 1, 'html': 0},
+            yield SplashRequest(
+                link.url,
+                self.parse_link,
+                endpoint='render.json',
+                args={
+                    'har': 1,
+                    'html': 1,
                 }
-            })
+            )
 
     def parse_link(self, response):
-        res = json.loads(response.body_as_unicode())
-        print(res["har"]["log"]["pages"])
+        print("PARSED", response.real_url, response.url)
+        print(response.css("title").extract())
+        print(response.data["har"]["log"]["pages"])
+        print(response.headers.get('Content-Type'))

--- a/scrapyjs/__init__.py
+++ b/scrapyjs/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from .middleware import SplashMiddleware, SlotPolicy
+from .middleware import SplashMiddleware, SlotPolicy, SplashCookiesMiddleware
 from .dupefilter import SplashAwareDupeFilter, splash_request_fingerprint
 from .cache import SplashAwareFSCacheStorage
 from .response import SplashResponse, SplashTextResponse, SplashJsonResponse

--- a/scrapyjs/__init__.py
+++ b/scrapyjs/__init__.py
@@ -4,3 +4,4 @@ from __future__ import absolute_import
 from .middleware import SplashMiddleware, SlotPolicy
 from .dupefilter import SplashAwareDupeFilter, splash_request_fingerprint
 from .cache import SplashAwareFSCacheStorage
+from .response import SplashResponse, SplashTextResponse, SplashJsonResponse

--- a/scrapyjs/__init__.py
+++ b/scrapyjs/__init__.py
@@ -5,3 +5,4 @@ from .middleware import SplashMiddleware, SlotPolicy
 from .dupefilter import SplashAwareDupeFilter, splash_request_fingerprint
 from .cache import SplashAwareFSCacheStorage
 from .response import SplashResponse, SplashTextResponse, SplashJsonResponse
+from .request import SplashRequest

--- a/scrapyjs/cache.py
+++ b/scrapyjs/cache.py
@@ -18,6 +18,9 @@ from .dupefilter import splash_request_fingerprint
 
 
 class SplashAwareFSCacheStorage(FilesystemCacheStorage):
+    # FIXME: storage should restore Splash response classes
+    # instead of regular Scrapy response classes.
+
     def _get_request_path(self, spider, request):
         key = splash_request_fingerprint(request)
         return os.path.join(self.cachedir, spider.name, key[0:2], key)

--- a/scrapyjs/cache.py
+++ b/scrapyjs/cache.py
@@ -18,9 +18,6 @@ from .dupefilter import splash_request_fingerprint
 
 
 class SplashAwareFSCacheStorage(FilesystemCacheStorage):
-    # FIXME: storage should restore Splash response classes
-    # instead of regular Scrapy response classes.
-
     def _get_request_path(self, spider, request):
         key = splash_request_fingerprint(request)
         return os.path.join(self.cachedir, spider.name, key[0:2], key)

--- a/scrapyjs/cookies.py
+++ b/scrapyjs/cookies.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""
+Cookie-related utilities.
+"""
+from __future__ import absolute_import
+import time
+import calendar
+
+from six.moves.http_cookiejar import CookieJar, Cookie, DefaultCookiePolicy
+
+
+class SplashCookiePolicy(DefaultCookiePolicy):
+    """
+    Policy for shared Splash CookieJars.
+
+    Unlike regular CookieJar we need to send all cookies in each request,
+    not only matching cookies, because Splash fetches related resources.
+    Splash handles domain/path filtering itself.
+    """
+    def set_ok_verifiability(self, cookie, request):
+        return True
+
+    def set_ok_path(self, cookie, request):
+        return True
+
+    def set_ok_domain(self, cookie, request):
+        return True
+
+    def set_ok_port(self, cookie, request):
+        return True
+
+    def return_ok(self, cookie, request):
+        """Return true if (and only if) cookie should be returned to server."""
+        return True
+
+    def domain_return_ok(self, domain, request):
+        """Return false if cookies should not be returned, given cookie domain.
+        """
+        return True
+
+    def path_return_ok(self, path, request):
+        """Return false if cookies should not be returned, given cookie path.
+        """
+        return True
+
+
+def jar_to_har(cookiejar):
+    """ Convert CookieJar to HAR cookies format """
+    return [cookie_to_har(c) for c in cookiejar]
+
+
+def har_to_jar(cookiejar, har_cookies):
+    """ Add HAR cookies to the cookiejar """
+    for c in har_cookies:
+        cookiejar.set_cookie(har_to_cookie(c))
+
+
+def har_to_cookie(har_cookie):
+    """
+    Convert a cookie dict in HAR format to a Cookie instance.
+
+    >>> har_cookie =  {
+    ...     "name": "TestCookie",
+    ...     "value": "Cookie Value",
+    ...     "path": "/foo",
+    ...     "domain": "www.janodvarko.cz",
+    ...     "expires": "2009-07-24T19:20:30Z",
+    ...     "httpOnly": True,
+    ...     "secure": True,
+    ...     "comment": "this is a test"
+    ... }
+    >>> cookie = har_to_cookie(har_cookie)
+    >>> cookie.name
+    'TestCookie'
+    >>> cookie.value
+    'Cookie Value'
+    >>> cookie.port
+    >>> cookie.domain
+    'www.janodvarko.cz'
+    >>> cookie.path
+    '/foo'
+    >>> cookie.secure
+    True
+    >>> cookie.expires
+    1248463230
+    >>> cookie.comment
+    'this is a test'
+    >>> cookie.get_nonstandard_attr('HttpOnly')
+    True
+    """
+
+    expires_timestamp = None
+    if har_cookie.get('expires'):
+        expires = time.strptime(har_cookie['expires'], "%Y-%m-%dT%H:%M:%SZ")
+        expires_timestamp = calendar.timegm(expires)
+
+    return create_cookie(
+        comment=har_cookie.get('comment'),
+        comment_url=bool(har_cookie.get('comment')),
+        discard=False,
+        domain=har_cookie.get('domain'),
+        expires=expires_timestamp,
+        name=har_cookie['name'],
+        path=har_cookie.get('path'),
+        port=None,
+        rest={'HttpOnly': har_cookie.get('httpOnly', False)},
+        rfc2109=False,
+        secure=har_cookie.get('secure', False),
+        value=har_cookie['value'],
+        version=har_cookie.get('version') or 0,
+    )
+
+
+def cookie_to_har(cookie):
+    """
+    Convert a Cookie instance to a dict in HAR cookie format.
+    """
+    c = {
+        'name': cookie.name,
+        'value': cookie.value,
+        'secure': cookie.secure,
+    }
+    if cookie.path_specified:
+        c['path'] = cookie.path
+
+    if cookie.domain_specified:
+        c['domain'] = cookie.domain
+
+    if cookie.expires:
+        tm = time.localtime(cookie.expires)
+        c['expires'] = time.strftime("%Y-%m-%dT%H:%M:%SZ", tm)
+
+    http_only = cookie.get_nonstandard_attr('HttpOnly')
+    if http_only is not None:
+        c['httpOnly'] = bool(http_only)
+
+    if cookie.comment:
+        c['comment'] = cookie.comment
+
+    return c
+
+
+# Stolen from
+# https://github.com/kennethreitz/requests/blob/master/requests/cookies.py:
+def create_cookie(name, value, **kwargs):
+    """Make a cookie from underspecified parameters.
+
+    By default, the pair of `name` and `value` will be set for the domain ''
+    and sent on every request (this is sometimes called a "supercookie").
+    """
+    result = dict(
+        version=0,
+        name=name,
+        value=value,
+        port=None,
+        domain='',
+        path='/',
+        secure=False,
+        expires=None,
+        discard=True,
+        comment=None,
+        comment_url=None,
+        rest={'HttpOnly': None},
+        rfc2109=False,)
+
+    badargs = set(kwargs) - set(result)
+    if badargs:
+        err = 'create_cookie() got unexpected keyword arguments: %s'
+        raise TypeError(err % list(badargs))
+
+    result.update(kwargs)
+    result['port_specified'] = bool(result['port'])
+    result['domain_specified'] = bool(result['domain'])
+    result['domain_initial_dot'] = result['domain'].startswith('.')
+    result['path_specified'] = bool(result['path'])
+
+    return Cookie(**result)

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -164,4 +164,3 @@ class SplashMiddleware(object):
         return self.crawler.engine.downloader._get_slot_key(
             request_or_response, None
         )
-

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -137,12 +137,14 @@ class SplashMiddleware(object):
         if splash_options.get('dont_process_response', False):
             return response
 
-        # create a custom Response subclass based on response Content-Type
-        # XXX: usually request is assigned to response only when all
-        # downloader middlewares are executed. Here it is set earlier.
-        # Does it have any negative consequences?
-        respcls = responsetypes.from_args(headers=response.headers)
-        return response.replace(cls=respcls, request=request)
+        from scrapyjs import SplashResponse, SplashTextResponse
+        if not isinstance(response, (SplashResponse, SplashTextResponse)):
+            # create a custom Response subclass based on response Content-Type
+            # XXX: usually request is assigned to response only when all
+            # downloader middlewares are executed. Here it is set earlier.
+            # Does it have any negative consequences?
+            respcls = responsetypes.from_args(headers=response.headers)
+            return response.replace(cls=respcls, request=request)
 
     def _set_download_slot(self, request, meta, slot_policy):
         if slot_policy == SlotPolicy.PER_DOMAIN:

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -11,7 +11,7 @@ from scrapy.exceptions import NotConfigured
 from scrapy.http.headers import Headers
 
 from scrapyjs.responsetypes import responsetypes
-from scrapyjs.cookies import SplashCookiePolicy, jar_to_har, har_to_jar
+from scrapyjs.cookies import jar_to_har, har_to_jar
 
 
 logger = logging.getLogger(__name__)
@@ -35,10 +35,8 @@ class SplashCookiesMiddleware(object):
     It should process requests before SplashMiddleware, and process responses
     after SplashMiddleware.
     """
-    policy = SplashCookiePolicy()
-
     def __init__(self):
-        self.jars = defaultdict(lambda: CookieJar(policy=self.policy))
+        self.jars = defaultdict(CookieJar)
 
     def process_request(self, request, spider):
         """

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -95,9 +95,11 @@ class SplashMiddleware(object):
             # it when it's too small. Decreasing `download_timeout` is not
             # safe.
 
+            timeout_requested = float(args['timeout'])
+            timeout_expected = timeout_requested + self.splash_extra_timeout
+
             # no timeout means infinite timeout
             timeout_current = meta.get('download_timeout', 1e6)
-            timeout_expected = float(args['timeout']) + self.splash_extra_timeout
 
             if timeout_expected > timeout_current:
                 meta['download_timeout'] = timeout_expected

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -78,7 +78,7 @@ class SplashMiddleware(object):
             args.setdefault('http_method', request.method)
             # XXX: non-UTF8 bodies are not supported now
             args.setdefault('body', request.body.decode('utf8'))
-        body = json.dumps(args, ensure_ascii=False)
+        body = json.dumps(args, ensure_ascii=False, sort_keys=True)
 
         if 'timeout' in args:
             # User requested a Splash timeout explicitly.

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -86,6 +86,7 @@ class SplashCookiesMiddleware(object):
 
         jar = self.jars[session_id]
         har_to_jar(jar, response.data['cookies'])
+        response.cookiejar = jar
         return response
 
 

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -59,6 +59,10 @@ class SplashCookiesMiddleware(object):
             return
 
         jar = self.jars[splash_options['session_id']]
+
+        cookies = self._get_request_cookies(request)
+        har_to_jar(jar, cookies)
+
         splash_args['cookies'] = jar_to_har(jar)
 
     def process_response(self, request, response, spider):
@@ -86,6 +90,13 @@ class SplashCookiesMiddleware(object):
         har_to_jar(jar, response.data['cookies'])
         response.cookiejar = jar
         return response
+
+    def _get_request_cookies(self, request):
+        if isinstance(request.cookies, dict):
+            return [
+                {'name': k, 'value': v} for k, v in request.cookies.items()
+            ]
+        return request.cookies or []
 
 
 class SplashMiddleware(object):

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -134,6 +134,9 @@ class SplashMiddleware(object):
             'splash/%s/response_count/%s' % (endpoint, response.status)
         )
 
+        if splash_options.get('dont_process_response', False):
+            return response
+
         # create a custom Response subclass based on response Content-Type
         # XXX: usually request is assigned to response only when all
         # downloader middlewares are executed. Here it is set earlier.

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -135,8 +135,11 @@ class SplashMiddleware(object):
         )
 
         # create a custom Response subclass based on response Content-Type
+        # XXX: usually request is assigned to response only when all
+        # downloader middlewares are executed. Here it is set earlier.
+        # Does it have any negative consequences?
         respcls = responsetypes.from_args(headers=response.headers)
-        return response.replace(cls=respcls)
+        return response.replace(cls=respcls, request=request)
 
     def _set_download_slot(self, request, meta, slot_policy):
         if slot_policy == SlotPolicy.PER_DOMAIN:

--- a/scrapyjs/request.py
+++ b/scrapyjs/request.py
@@ -25,6 +25,7 @@ class SplashRequest(scrapy.Request):
                  splash_url=None,
                  slot_policy=SlotPolicy.PER_DOMAIN,
                  splash_headers=None,
+                 dont_process_response=False,
                  **kwargs):
 
         if url is None:
@@ -38,6 +39,8 @@ class SplashRequest(scrapy.Request):
             splash_meta['splash_url'] = splash_url
         if splash_headers is not None:
             splash_meta['splash_headers'] = splash_headers
+        if dont_process_response:
+            splash_meta['dont_process_response'] = True
 
         _args = {'url': url}  # put URL to args in order to preserve #fragment
         _args.update(args or {})

--- a/scrapyjs/request.py
+++ b/scrapyjs/request.py
@@ -26,9 +26,9 @@ class SplashRequest(scrapy.Request):
                  slot_policy=SlotPolicy.PER_DOMAIN,
                  splash_headers=None,
                  **kwargs):
+
         if url is None:
             url = 'about:blank'
-        self._original_url = url
 
         meta = kwargs.pop('meta', {})
         splash_meta = meta.setdefault('splash', {})
@@ -47,12 +47,15 @@ class SplashRequest(scrapy.Request):
         super(SplashRequest, self).__init__(url, callback, method, meta=meta,
                                             **kwargs)
 
-    def replace(self, *args, **kwargs):
-        obj = super(SplashRequest, self).replace(*args, **kwargs)
-        obj._original_url = self._original_url
-        return obj
+    @property
+    def _original_url(self):
+        return self.meta.get('splash', {}).get('args', {}).get('url')
+
+    @property
+    def _original_method(self):
+        return self.meta.get('splash', {}).get('args', {}).get('http_method', 'GET')
 
     def __str__(self):
-        return "<%s %s %s>" % (self.method, self.url, self._original_url)
+        return "<%s %s via %s>" % (self._original_method, self._original_url, self.url)
 
     __repr__ = __str__

--- a/scrapyjs/request.py
+++ b/scrapyjs/request.py
@@ -58,6 +58,10 @@ class SplashRequest(scrapy.Request):
                                             **kwargs)
 
     @property
+    def _processed(self):
+        return '_splash_processed' in self.meta
+
+    @property
     def _original_url(self):
         return self.meta.get('splash', {}).get('args', {}).get('url')
 
@@ -66,6 +70,8 @@ class SplashRequest(scrapy.Request):
         return self.meta.get('splash', {}).get('args', {}).get('http_method', 'GET')
 
     def __str__(self):
+        if not self._processed:
+            return super(SplashRequest, self).__str__()
         return "<%s %s via %s>" % (self._original_method, self._original_url, self.url)
 
     __repr__ = __str__

--- a/scrapyjs/request.py
+++ b/scrapyjs/request.py
@@ -26,6 +26,7 @@ class SplashRequest(scrapy.Request):
                  slot_policy=SlotPolicy.PER_DOMAIN,
                  splash_headers=None,
                  dont_process_response=False,
+                 dont_send_headers=False,
                  magic_response=True,
                  session_id='default',
                  **kwargs):
@@ -45,6 +46,8 @@ class SplashRequest(scrapy.Request):
             splash_meta['dont_process_response'] = True
         else:
             splash_meta.setdefault('magic_response', magic_response)
+        if dont_send_headers:
+            splash_meta['dont_send_headers'] = True
 
         if session_id is not None:
             if splash_meta['endpoint'].strip('/') == 'execute':

--- a/scrapyjs/request.py
+++ b/scrapyjs/request.py
@@ -50,6 +50,10 @@ class SplashRequest(scrapy.Request):
         _args.update(splash_meta.get('args', {}))
         splash_meta['args'] = _args
 
+        # This is not strictly required, but it strengthens Splash
+        # requests against AjaxCrawlMiddleware
+        meta['ajax_crawlable'] = True
+
         super(SplashRequest, self).__init__(url, callback, method, meta=meta,
                                             **kwargs)
 

--- a/scrapyjs/request.py
+++ b/scrapyjs/request.py
@@ -26,6 +26,7 @@ class SplashRequest(scrapy.Request):
                  slot_policy=SlotPolicy.PER_DOMAIN,
                  splash_headers=None,
                  dont_process_response=False,
+                 magic_response=True,
                  **kwargs):
 
         if url is None:
@@ -41,6 +42,8 @@ class SplashRequest(scrapy.Request):
             splash_meta['splash_headers'] = splash_headers
         if dont_process_response:
             splash_meta['dont_process_response'] = True
+        else:
+            splash_meta.setdefault('magic_response', magic_response)
 
         _args = {'url': url}  # put URL to args in order to preserve #fragment
         _args.update(args or {})

--- a/scrapyjs/request.py
+++ b/scrapyjs/request.py
@@ -27,6 +27,7 @@ class SplashRequest(scrapy.Request):
                  splash_headers=None,
                  dont_process_response=False,
                  magic_response=True,
+                 session_id='default',
                  **kwargs):
 
         if url is None:
@@ -45,6 +46,10 @@ class SplashRequest(scrapy.Request):
         else:
             splash_meta.setdefault('magic_response', magic_response)
 
+        if session_id is not None:
+            if splash_meta['endpoint'].strip('/') == 'execute':
+                splash_meta.setdefault('session_id', session_id)
+
         _args = {'url': url}  # put URL to args in order to preserve #fragment
         _args.update(args or {})
         _args.update(splash_meta.get('args', {}))
@@ -62,12 +67,16 @@ class SplashRequest(scrapy.Request):
         return '_splash_processed' in self.meta
 
     @property
+    def _splash_args(self):
+        return self.meta.get('splash', {}).get('args', {})
+
+    @property
     def _original_url(self):
-        return self.meta.get('splash', {}).get('args', {}).get('url')
+        return self._splash_args.get('url')
 
     @property
     def _original_method(self):
-        return self.meta.get('splash', {}).get('args', {}).get('http_method', 'GET')
+        return self._splash_args.get('http_method', 'GET')
 
     def __str__(self):
         if not self._processed:

--- a/scrapyjs/response.py
+++ b/scrapyjs/response.py
@@ -7,7 +7,7 @@ import base64
 from scrapy.http import Response, TextResponse
 from scrapy import Selector
 
-from scrapyjs.utils import headers_to_scrapy
+from scrapyjs.utils import headers_to_scrapy, cookies_to_header_values, to_bytes
 
 
 class _SplashResponseMixin(object):
@@ -115,7 +115,10 @@ class SplashJsonResponse(SplashResponse):
             if 'headers' in self.data:
                 self.headers = headers_to_scrapy(self.data['headers'])
             if 'cookies' in self.data:
-                raise NotImplementedError("TODO: add Set-Cookie header")
+                cookie_values = cookies_to_header_values(self.data['cookies'])
+                set_cookie_values = self.headers.getlist('Set-Cookie')
+                set_cookie_values.extend(to_bytes(c) for c in cookie_values)
+                self.headers.setlist('Set-Cookie', set_cookie_values)
 
     @property
     def data(self):

--- a/scrapyjs/response.py
+++ b/scrapyjs/response.py
@@ -155,12 +155,3 @@ class SplashJsonResponse(SplashResponse):
         # response.headers
         if 'headers' in self.data:
             self.headers = headers_to_scrapy(self.data['headers'])
-
-    def replace(self, *args, **kwargs):
-        cookiejar = 'NA'
-        if 'cookiejar' in kwargs:
-            cookiejar = kwargs.pop('cookiejar')
-        resp = super(SplashJsonResponse, self).replace(*args, **kwargs)
-        resp.cookiejar = self.cookiejar if cookiejar == 'NA' else cookiejar
-        return resp
-

--- a/scrapyjs/response.py
+++ b/scrapyjs/response.py
@@ -72,7 +72,8 @@ class SplashTextResponse(_SplashResponseMixin, TextResponse):
 class SplashJsonResponse(SplashResponse):
     """
     Splash Response with JSON data. It provides a convenient way to access
-    parsed JSON response using ``response.data`` attribute.
+    parsed JSON response using ``response.data`` attribute and exposes
+    current Splash cookiejar when it is available.
 
     If Scrapy-Splash response magic is enabled in request
     (['splash']['magic_response'] is not False), several other response
@@ -85,6 +86,7 @@ class SplashJsonResponse(SplashResponse):
     * response.status is set from the value of 'http_status' key.
     """
     def __init__(self, *args, **kwargs):
+        self.cookiejar = None
         self._cached_ubody = None
         self._cached_data = None
         self._cached_selector = None
@@ -153,3 +155,12 @@ class SplashJsonResponse(SplashResponse):
         # response.headers
         if 'headers' in self.data:
             self.headers = headers_to_scrapy(self.data['headers'])
+
+    def replace(self, *args, **kwargs):
+        cookiejar = 'NA'
+        if 'cookiejar' in kwargs:
+            cookiejar = kwargs.pop('cookiejar')
+        resp = super(SplashJsonResponse, self).replace(*args, **kwargs)
+        resp.cookiejar = self.cookiejar if cookiejar == 'NA' else cookiejar
+        return resp
+

--- a/scrapyjs/response.py
+++ b/scrapyjs/response.py
@@ -7,7 +7,7 @@ import base64
 from scrapy.http import Response, TextResponse
 from scrapy import Selector
 
-from scrapyjs.utils import headers_to_scrapy, cookies_to_header_values, to_bytes
+from scrapyjs.utils import headers_to_scrapy
 
 
 class _SplashResponseMixin(object):
@@ -78,7 +78,7 @@ class SplashJsonResponse(SplashResponse):
     (['splash']['magic_response'] is not False), several other response
     attributes (headers, body, url, status code) are set automatically:
 
-    * response.headers are filled from 'headers' and 'cookies' keys;
+    * response.headers are filled from 'headers' keys;
     * response.url is set to the value of 'url' key;
     * response.body is set to the value of 'html' key,
       or to base64-decoded value of 'body' key;
@@ -153,8 +153,3 @@ class SplashJsonResponse(SplashResponse):
         # response.headers
         if 'headers' in self.data:
             self.headers = headers_to_scrapy(self.data['headers'])
-        if 'cookies' in self.data:
-            cookie_values = cookies_to_header_values(self.data['cookies'])
-            set_cookie_values = self.headers.getlist(b'Set-Cookie')
-            set_cookie_values.extend(to_bytes(c) for c in cookie_values)
-            self.headers.setlist(b'Set-Cookie', set_cookie_values)

--- a/scrapyjs/response.py
+++ b/scrapyjs/response.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import
 import json
 import base64
 
-from scrapy.http.headers import Headers
-
 from scrapy.http import Response, TextResponse
 from scrapy import Selector
+
+from scrapyjs.utils import headers_to_scrapy
 
 
 class _SplashResponseMixin(object):
@@ -113,30 +113,9 @@ class SplashJsonResponse(SplashResponse):
 
             # response.headers
             if 'headers' in self.data:
-                self.headers = self._build_headers(self.data['headers'])
+                self.headers = headers_to_scrapy(self.data['headers'])
             if 'cookies' in self.data:
                 raise NotImplementedError("TODO: add Set-Cookie header")
-
-    @classmethod
-    def _build_headers(cls, headers):
-        """
-        Return Headers instance from headers data.
-        3 data formats are supported:
-
-        * {name: value, ...} dict;
-        * [(name, value), ...] list;
-        * [{'name': name, 'value': value'}, ...] list (HAR headers format).
-        """
-        if isinstance(headers or {}, dict):
-            return Headers(headers or {})
-
-        if isinstance(headers[0], dict):
-            return Headers([
-                (d['name'], d.get('value', ''))
-                for d in headers
-            ])
-
-        return Headers(headers)
 
     @property
     def data(self):

--- a/scrapyjs/response.py
+++ b/scrapyjs/response.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import json
+import base64
+
+from scrapy.http import Response, TextResponse
+from scrapy import Selector
+
+
+class _RealUrlMixin(object):
+    """ This mixin fixes response.url and adds response.real_url """
+    def __init__(self, url, *args, **kwargs):
+        real_url = kwargs.pop('real_url', None)
+        if real_url is not None:
+            self.real_url = real_url
+        else:
+            self.real_url = None
+            request = kwargs['request']
+            splash_options = request.meta.get("_splash_processed")
+            if splash_options:
+                splash_args = splash_options.get('args', {})
+                _url = splash_args.get('url', None)
+                if _url is not None:
+                    self.real_url = url
+                    url = _url
+        super(_RealUrlMixin, self).__init__(url, *args, **kwargs)
+
+    def replace(self, *args, **kwargs):
+        """Create a new Response with the same attributes except for those
+        given new values.
+        """
+        for x in ['url', 'status', 'headers', 'body', 'request', 'flags',
+                  'real_url']:
+            kwargs.setdefault(x, getattr(self, x))
+        cls = kwargs.pop('cls', self.__class__)
+        return cls(*args, **kwargs)
+
+
+class SplashResponse(_RealUrlMixin, Response):
+    """
+    This Response subclass sets response.url to the URL of a remote website
+    instead of an URL of Splash server. "Real" response URL is still available
+    as ``response.real_url``.
+    """
+
+
+class SplashTextResponse(_RealUrlMixin, TextResponse):
+    """
+    This TextResponse subclass sets response.url to the URL of a remote website
+    instead of an URL of Splash server. "Real" response URL is still available
+    as ``response.real_url``.
+    """
+    def replace(self, *args, **kwargs):
+        kwargs.setdefault('encoding', self.encoding)
+        return _RealUrlMixin.replace(self, *args, **kwargs)
+
+
+class SplashJsonResponse(SplashResponse):
+    """
+    Splash Response with JSON data. It provides a convenient way to access
+    parsed JSON response using ``response.data`` attribute.
+
+    TODO: If Scrapy-Splash magic integration is enabled in request,
+    several other response attributes (headers, body, url, status code)
+    are set automatically:
+
+    * response.headers are filled from 'headers' key;
+    * response.url is set to the value of 'url' key;
+    * response.body is set to the value of 'html' key,
+      or to base64-decoded value of 'body' key;
+    * response.status is set from the value of 'status' key.
+    """
+    def __init__(self, *args, **kwargs):
+        self._cached_ubody = None
+        self._cached_data = None
+        self._cached_selector = None
+        kwargs.pop('encoding', None)  # encoding is always utf-8
+        super(SplashJsonResponse, self).__init__(*args, **kwargs)
+
+    @property
+    def data(self):
+        if self._cached_data is None:
+            self._cached_data = json.loads(self._decoded_body)
+        return self._cached_data
+
+    @property
+    def text(self):
+        return self._decoded_body
+
+    def body_as_unicode(self):
+        return self._decoded_body
+
+    @property
+    def _decoded_body(self):
+        if self._cached_ubody is None:
+            self._cached_ubody = self.body.decode(self.encoding)
+        return self._cached_ubody
+
+    @property
+    def encoding(self):
+        return 'utf8'
+
+    @property
+    def selector(self):
+        if self._cached_selector is None:
+            self._cached_selector = Selector(text=self.text, type='html')
+        return self._cached_selector
+
+    def xpath(self, query):
+        return self.selector.xpath(query)
+
+    def css(self, query):
+        return self.selector.css(query)

--- a/scrapyjs/response.py
+++ b/scrapyjs/response.py
@@ -93,32 +93,7 @@ class SplashJsonResponse(SplashResponse):
 
         # FIXME: it assumes self.request is set
         if self._splash_options().get('magic_response', True):
-
-            # response.status
-            if 'http_status' in self.data:
-                self.status = int(self.data['http_status'])
-
-            # response.url
-            if 'url' in self.data:
-                self._url = self.data['url']
-
-            # response.body
-            if 'body' in self.data:
-                self._body = base64.b64decode(self.data['body'])
-                self._cached_ubody = self._body.decode(self.encoding)
-            elif 'html' in self.data:
-                self._cached_ubody = self.data['html']
-                self._body = self._cached_ubody.encode(self.encoding)
-                self.headers[b"Content-Type"] = b"text/html; charset=utf-8"
-
-            # response.headers
-            if 'headers' in self.data:
-                self.headers = headers_to_scrapy(self.data['headers'])
-            if 'cookies' in self.data:
-                cookie_values = cookies_to_header_values(self.data['cookies'])
-                set_cookie_values = self.headers.getlist('Set-Cookie')
-                set_cookie_values.extend(to_bytes(c) for c in cookie_values)
-                self.headers.setlist('Set-Cookie', set_cookie_values)
+            self._load_from_json()
 
     @property
     def data(self):
@@ -154,3 +129,32 @@ class SplashJsonResponse(SplashResponse):
 
     def css(self, query):
         return self.selector.css(query)
+
+    def _load_from_json(self):
+        """ Fill response attributes from JSON results """
+
+        # response.status
+        if 'http_status' in self.data:
+            self.status = int(self.data['http_status'])
+
+        # response.url
+        if 'url' in self.data:
+            self._url = self.data['url']
+
+        # response.body
+        if 'body' in self.data:
+            self._body = base64.b64decode(self.data['body'])
+            self._cached_ubody = self._body.decode(self.encoding)
+        elif 'html' in self.data:
+            self._cached_ubody = self.data['html']
+            self._body = self._cached_ubody.encode(self.encoding)
+            self.headers[b"Content-Type"] = b"text/html; charset=utf-8"
+
+        # response.headers
+        if 'headers' in self.data:
+            self.headers = headers_to_scrapy(self.data['headers'])
+        if 'cookies' in self.data:
+            cookie_values = cookies_to_header_values(self.data['cookies'])
+            set_cookie_values = self.headers.getlist(b'Set-Cookie')
+            set_cookie_values.extend(to_bytes(c) for c in cookie_values)
+            self.headers.setlist(b'Set-Cookie', set_cookie_values)

--- a/scrapyjs/response.py
+++ b/scrapyjs/response.py
@@ -4,27 +4,32 @@ from __future__ import absolute_import
 import json
 import base64
 
+from scrapy.http.headers import Headers
+
 from scrapy.http import Response, TextResponse
 from scrapy import Selector
 
 
-class _RealUrlMixin(object):
-    """ This mixin fixes response.url and adds response.real_url """
+class _SplashResponseMixin(object):
+    """
+    This mixin fixes response.url and adds response.real_url
+    """
     def __init__(self, url, *args, **kwargs):
         real_url = kwargs.pop('real_url', None)
         if real_url is not None:
             self.real_url = real_url
         else:
             self.real_url = None
+            # FIXME: create a .request @property with a setter?
+            # Scrapy doesn't pass request to Response constructor;
+            # it is worked around in SplashMiddleware.
             request = kwargs['request']
-            splash_options = request.meta.get("_splash_processed")
-            if splash_options:
-                splash_args = splash_options.get('args', {})
-                _url = splash_args.get('url', None)
-                if _url is not None:
-                    self.real_url = url
-                    url = _url
-        super(_RealUrlMixin, self).__init__(url, *args, **kwargs)
+            splash_args = self._splash_args(request)
+            _url = splash_args.get('url')
+            if _url is not None:
+                self.real_url = url
+                url = _url
+        super(_SplashResponseMixin, self).__init__(url, *args, **kwargs)
 
     def replace(self, *args, **kwargs):
         """Create a new Response with the same attributes except for those
@@ -36,8 +41,16 @@ class _RealUrlMixin(object):
         cls = kwargs.pop('cls', self.__class__)
         return cls(*args, **kwargs)
 
+    def _splash_options(self, request=None):
+        if request is None:
+            request = self.request
+        return request.meta.get("_splash_processed", {})
 
-class SplashResponse(_RealUrlMixin, Response):
+    def _splash_args(self, request=None):
+        return self._splash_options(request).get('args', {})
+
+
+class SplashResponse(_SplashResponseMixin, Response):
     """
     This Response subclass sets response.url to the URL of a remote website
     instead of an URL of Splash server. "Real" response URL is still available
@@ -45,7 +58,7 @@ class SplashResponse(_RealUrlMixin, Response):
     """
 
 
-class SplashTextResponse(_RealUrlMixin, TextResponse):
+class SplashTextResponse(_SplashResponseMixin, TextResponse):
     """
     This TextResponse subclass sets response.url to the URL of a remote website
     instead of an URL of Splash server. "Real" response URL is still available
@@ -53,7 +66,7 @@ class SplashTextResponse(_RealUrlMixin, TextResponse):
     """
     def replace(self, *args, **kwargs):
         kwargs.setdefault('encoding', self.encoding)
-        return _RealUrlMixin.replace(self, *args, **kwargs)
+        return _SplashResponseMixin.replace(self, *args, **kwargs)
 
 
 class SplashJsonResponse(SplashResponse):
@@ -61,15 +74,15 @@ class SplashJsonResponse(SplashResponse):
     Splash Response with JSON data. It provides a convenient way to access
     parsed JSON response using ``response.data`` attribute.
 
-    TODO: If Scrapy-Splash magic integration is enabled in request,
-    several other response attributes (headers, body, url, status code)
-    are set automatically:
+    If Scrapy-Splash response magic is enabled in request
+    (['splash']['magic_response'] is not False), several other response
+    attributes (headers, body, url, status code) are set automatically:
 
-    * response.headers are filled from 'headers' key;
+    * response.headers are filled from 'headers' and 'cookies' keys;
     * response.url is set to the value of 'url' key;
     * response.body is set to the value of 'html' key,
       or to base64-decoded value of 'body' key;
-    * response.status is set from the value of 'status' key.
+    * response.status is set from the value of 'http_status' key.
     """
     def __init__(self, *args, **kwargs):
         self._cached_ubody = None
@@ -78,21 +91,67 @@ class SplashJsonResponse(SplashResponse):
         kwargs.pop('encoding', None)  # encoding is always utf-8
         super(SplashJsonResponse, self).__init__(*args, **kwargs)
 
+        # FIXME: it assumes self.request is set
+        if self._splash_options().get('magic_response', True):
+
+            # response.status
+            if 'http_status' in self.data:
+                self.status = int(self.data['http_status'])
+
+            # response.url
+            if 'url' in self.data:
+                self._url = self.data['url']
+
+            # response.body
+            if 'body' in self.data:
+                self._body = base64.b64decode(self.data['body'])
+                self._cached_ubody = self._body.decode(self.encoding)
+            elif 'html' in self.data:
+                self._cached_ubody = self.data['html']
+                self._body = self._cached_ubody.encode(self.encoding)
+
+            # response.headers
+            if 'headers' in self.data:
+                self.headers = self._build_headers(self.data['headers'])
+            if 'cookies' in self.data:
+                raise NotImplementedError("TODO: add Set-Cookie header")
+
+    @classmethod
+    def _build_headers(cls, headers):
+        """
+        Return Headers instance from headers data.
+        3 data formats are supported:
+
+        * {name: value, ...} dict;
+        * [(name, value), ...] list;
+        * [{'name': name, 'value': value'}, ...] list (HAR headers format).
+        """
+        if isinstance(headers or {}, dict):
+            return Headers(headers or {})
+
+        if isinstance(headers[0], dict):
+            return Headers([
+                (d['name'], d.get('value', ''))
+                for d in headers
+            ])
+
+        return Headers(headers)
+
     @property
     def data(self):
         if self._cached_data is None:
-            self._cached_data = json.loads(self._decoded_body)
+            self._cached_data = json.loads(self._ubody)
         return self._cached_data
 
     @property
     def text(self):
-        return self._decoded_body
+        return self._ubody
 
     def body_as_unicode(self):
-        return self._decoded_body
+        return self._ubody
 
     @property
-    def _decoded_body(self):
+    def _ubody(self):
         if self._cached_ubody is None:
             self._cached_ubody = self.body.decode(self.encoding)
         return self._cached_ubody

--- a/scrapyjs/response.py
+++ b/scrapyjs/response.py
@@ -109,6 +109,7 @@ class SplashJsonResponse(SplashResponse):
             elif 'html' in self.data:
                 self._cached_ubody = self.data['html']
                 self._body = self._cached_ubody.encode(self.encoding)
+                self.headers[b"Content-Type"] = b"text/html; charset=utf-8"
 
             # response.headers
             if 'headers' in self.data:

--- a/scrapyjs/responsetypes.py
+++ b/scrapyjs/responsetypes.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from scrapy.http import Response
+from scrapy.responsetypes import ResponseTypes
+
+import scrapyjs
+
+
+class SplashResponseTypes(ResponseTypes):
+    CLASSES = {
+        'text/html': 'scrapyjs.response.SplashTextResponse',
+        'application/atom+xml': 'scrapyjs.response.SplashTextResponse',
+        'application/rdf+xml': 'scrapyjs.response.SplashTextResponse',
+        'application/rss+xml': 'scrapyjs.response.SplashTextResponse',
+        'application/xhtml+xml': 'scrapyjs.response.SplashTextResponse',
+        'application/vnd.wap.xhtml+xml': 'scrapyjs.response.SplashTextResponse',
+        'application/xml': 'scrapyjs.response.SplashTextResponse',
+        'application/json': 'scrapyjs.response.SplashJsonResponse',
+        'application/x-json': 'scrapyjs.response.SplashJsonResponse',
+        'application/javascript': 'scrapyjs.response.SplashTextResponse',
+        'application/x-javascript': 'scrapyjs.response.SplashTextResponse',
+        'text/xml': 'scrapyjs.response.SplashTextResponse',
+        'text/*': 'scrapyjs.response.SplashTextResponse',
+    }
+
+    def from_args(self, headers=None, url=None, filename=None, body=None):
+        """Guess the most appropriate Response class based on
+        the given arguments."""
+        cls = super(SplashResponseTypes, self).from_args(
+            headers=headers,
+            url=url,
+            filename=filename,
+            body=body
+        )
+        if cls is Response:
+            cls = scrapyjs.SplashResponse
+        return cls
+
+
+responsetypes = SplashResponseTypes()

--- a/scrapyjs/utils.py
+++ b/scrapyjs/utils.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 import hashlib
 import six
+from six.moves.http_cookies import SimpleCookie, Morsel
 
 from scrapy.http import Headers
 
@@ -55,5 +56,91 @@ def headers_to_scrapy(headers):
         ])
 
     return Headers(headers)
+
+
+def cookies_to_header_values(cookie_data):
+    """
+    Convert cookie data to a list of Set-Cookie header values.
+    Cookie data can be either
+
+    * a list of strings (it is returned as-is);
+    * a list of dicts in HAR cookie format
+      (see http://www.softwareishard.com/blog/har-12-spec/#cookies)
+    """
+    if not cookie_data:
+        return []
+
+    first = cookie_data[0]
+
+    if isinstance(first, six.string_types):
+        return cookie_data
+
+    if isinstance(first, dict):  # HAR cookies
+        return [har_cookie_to_morsel(c).OutputString() for c in cookie_data]
+
+    raise ValueError("Invalid data format: expected a list of strings or "
+                     "dicts, got a list of %s instead" % first.__class__)
+
+
+def har_cookie_to_morsel(cookie):
+    """
+    Convert a cookie in HAR format to http.cookies.Morsel instance.
+
+    >>> har_cookie =  {
+    ...     "name": "TestCookie",
+    ...     "value": "Cookie Value",
+    ...     "path": "/",
+    ...     "domain": "www.janodvarko.cz",
+    ...     "expires": "2009-07-24T19:20:30.123+02:00",
+    ...     "httpOnly": False,
+    ...     "secure": True,
+    ...     "comment": "this is a test"
+    ... }
+    >>> m = har_cookie_to_morsel(har_cookie)
+    >>> m.key
+    'TestCookie'
+    >>> m.value
+    'Cookie Value'
+    >>> m['expires']
+    '2009-07-24T19:20:30.123+02:00'
+    >>> m['path']
+    '/'
+    >>> m['comment']
+    'this is a test'
+    >>> m['domain']
+    'www.janodvarko.cz'
+    >>> m['max-age']
+    ''
+    >>> m['secure']
+    True
+    >>> m['version']
+    ''
+    >>> m['httponly']
+    ''
+    """
+    kv_map = {
+        'path': 'path',
+        'domain': 'domain',
+        'expires': 'expires',
+        'httpOnly': 'httponly',
+        'httponly': 'httponly',
+        'version': 'version',
+        'max-age': 'max-age',
+        'secure': 'secure',
+        'comment': 'comment',
+    }
+
+    c = SimpleCookie()
+    c[cookie['name']] = cookie.get('value', '')
+    for key, morsel in c.items():
+        break
+    for har_key, py_key in kv_map.items():
+        if har_key in cookie:
+            value = cookie[har_key]
+            # Python 2.x workaround: in Python 2.x False value for
+            # httponly still makes the attribute set.
+            if value or (py_key not in {'secure', 'httponly'}):
+                morsel[py_key] = value
+    return morsel
 
 

--- a/scrapyjs/utils.py
+++ b/scrapyjs/utils.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import hashlib
 import six
 
+from scrapy.http import Headers
+
 try:
     from scrapy.utils.python import to_bytes
 except ImportError:
@@ -32,5 +34,26 @@ def dict_hash(obj, start=''):
             raise ValueError("Unsupported value type: %s" % obj.__class__)
         h.update(to_bytes(value))
     return h.hexdigest()
+
+
+def headers_to_scrapy(headers):
+    """
+    Return scrapy.http.Headers instance from headers data.
+    3 data formats are supported:
+
+    * {name: value, ...} dict;
+    * [(name, value), ...] list;
+    * [{'name': name, 'value': value'}, ...] list (HAR headers format).
+    """
+    if isinstance(headers or {}, dict):
+        return Headers(headers or {})
+
+    if isinstance(headers[0], dict):
+        return Headers([
+            (d['name'], d.get('value', ''))
+            for d in headers
+        ])
+
+    return Headers(headers)
 
 

--- a/scrapyjs/utils.py
+++ b/scrapyjs/utils.py
@@ -66,3 +66,12 @@ def headers_to_scrapy(headers):
     return Headers(headers)
 
 
+def scrapy_headers_to_unicode_dict(headers):
+    """
+    Convert scrapy.http.Headers instance to a dictionary
+    suitable for JSON encoding.
+    """
+    return {
+        to_unicode(key): to_unicode(b','.join(value))
+        for key, value in headers.items()
+    }

--- a/scrapyjs/utils.py
+++ b/scrapyjs/utils.py
@@ -2,10 +2,8 @@
 from __future__ import absolute_import
 import hashlib
 import six
-from six.moves.http_cookies import SimpleCookie, Morsel
 
 from scrapy.http import Headers
-
 try:
     from scrapy.utils.python import to_bytes, to_unicode, to_native_str
 except ImportError:
@@ -66,95 +64,5 @@ def headers_to_scrapy(headers):
         ])
 
     return Headers(headers)
-
-
-def cookies_to_header_values(cookie_data):
-    """
-    Convert cookie data to a list of Set-Cookie header values.
-    Cookie data can be either
-
-    * a list of strings (it is returned as-is);
-    * a list of dicts in HAR cookie format
-      (see http://www.softwareishard.com/blog/har-12-spec/#cookies)
-    """
-    if not cookie_data:
-        return []
-
-    first = cookie_data[0]
-
-    if isinstance(first, six.string_types):
-        return cookie_data
-
-    if isinstance(first, dict):  # HAR cookies
-        return [har_cookie_to_morsel(c).OutputString() for c in cookie_data]
-
-    raise ValueError("Invalid data format: expected a list of strings or "
-                     "dicts, got a list of %s instead" % first.__class__)
-
-
-def har_cookie_to_morsel(cookie):
-    """
-    Convert a cookie in HAR format to http.cookies.Morsel instance.
-
-    >>> har_cookie =  {
-    ...     "name": "TestCookie",
-    ...     "value": "Cookie Value",
-    ...     "path": "/",
-    ...     "domain": "www.janodvarko.cz",
-    ...     "expires": "2009-07-24T19:20:30.123+02:00",
-    ...     "httpOnly": False,
-    ...     "secure": True,
-    ...     "comment": "this is a test"
-    ... }
-    >>> m = har_cookie_to_morsel(har_cookie)
-    >>> m.key
-    'TestCookie'
-    >>> m.value
-    'Cookie Value'
-    >>> m['expires']
-    '2009-07-24T19:20:30.123+02:00'
-    >>> m['path']
-    '/'
-    >>> m['comment']
-    'this is a test'
-    >>> m['domain']
-    'www.janodvarko.cz'
-    >>> m['max-age']
-    ''
-    >>> m['secure']
-    True
-    >>> m['version']
-    ''
-    >>> m['httponly']
-    ''
-    """
-    kv_map = {
-        'path': 'path',
-        'domain': 'domain',
-        'expires': 'expires',
-        'httpOnly': 'httponly',
-        'httponly': 'httponly',
-        'version': 'version',
-        'max-age': 'max-age',
-        'secure': 'secure',
-        'comment': 'comment',
-    }
-
-    c = SimpleCookie()
-    c[to_native_str(cookie['name'])] = to_native_str(cookie.get('value', ''))
-    for key, morsel in c.items():
-        break
-    for har_key, py_key in kv_map.items():
-        if har_key in cookie:
-            value = cookie[har_key]
-            # Python 2.x workaround: in Python 2.x False value for
-            # httponly still makes the attribute set.
-            if value or (py_key not in {'secure', 'httponly'}):
-                if isinstance(value, six.string_types):
-                    # another Python 2.x workaround: cookie methods
-                    # don't accept unicode
-                    value = to_native_str(value)
-                morsel[py_key] = value
-    return morsel
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -64,6 +64,7 @@ def test_splash_request():
     cookie_mw = _get_cookie_mw()
 
     req = SplashRequest("http://example.com?foo=bar&url=1&wait=100")
+    assert repr(req) == "<GET http://example.com?foo=bar&url=1&wait=100>"
 
     # check request preprocessing
     req2 = cookie_mw.process_request(req, None) or req
@@ -74,6 +75,7 @@ def test_splash_request():
     assert req2.headers == {b'Content-Type': [b'application/json']}
     assert req2.method == 'POST'
     assert isinstance(req2, SplashRequest)
+    assert repr(req2) == "<GET http://example.com?foo=bar&url=1&wait=100 via http://127.0.0.1:8050/render.html>"
 
     expected_body = {'url': req.url}
     assert json.loads(to_native_str(req2.body)) == expected_body

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -192,7 +192,8 @@ def test_magic_response():
     req = SplashRequest('http://example.com/',
                         endpoint='execute',
                         args={'lua_source': 'function main() end'},
-                        magic_response=True)
+                        magic_response=True,
+                        cookies=[{'name': 'foo', 'value': 'bar'}])
     req = cookie_mw.process_request(req, None) or req
     req = mw.process_request(req, None) or req
 
@@ -207,7 +208,6 @@ def test_magic_response():
         ],
         'cookies': [
             {'name': 'bar', 'value': 'baz', 'domain': '.example.com'},
-            {'name': 'foo', 'value': 'bar'},
             {'name': 'session', 'value': '12345', 'path': '/',
              'expires': '2055-07-24T19:20:30Z'},
         ],
@@ -240,7 +240,8 @@ def test_magic_response():
     req = SplashRequest('http://example.com/foo',
                         endpoint='execute',
                         args={'lua_source': 'function main() end'},
-                        magic_response=True)
+                        magic_response=True,
+                        cookies={'spam': 'ham'})
     req = cookie_mw.process_request(req, None) or req
     req = mw.process_request(req, None) or req
 
@@ -265,14 +266,15 @@ def test_magic_response():
     resp2 = cookie_mw.process_response(req, resp2, None)
     assert isinstance(resp2, scrapyjs.SplashJsonResponse)
     assert resp2.data == resp_data
-    assert len(resp2.cookiejar) == 4
     cookies = [c for c in resp2.cookiejar]
-    assert {c.name for c in cookies} == {'foo', 'session', 'egg', 'bar'}
+    assert {c.name for c in cookies} == {'foo', 'session', 'egg', 'bar', 'spam'}
     for c in cookies:
         if c.name == 'session':
             assert c.expires == 2731692030
         if c.name == 'foo':
             assert c.value == ''
+        if c.name == 'spam':
+            assert c.value == 'ham'
 
 
 def test_magic_response2():

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -60,7 +60,8 @@ def test_splash_request():
 
     # check response post-processing
     response = TextResponse("http://127.0.0.1:8050/render.html",
-                            request=req2,
+                            # Scrapy doesn't pass request to constructor
+                            # request=req2,
                             headers={b'Content-Type': b'text/html'},
                             body=b"<html><body>Hello</body></html>")
     response2 = mw.process_response(req2, response, None)
@@ -123,7 +124,8 @@ def test_splash_requst_parameters():
     }
     res_body = json.dumps(res)
     response = TextResponse("http://mysplash.example.com/execute",
-                            request=req2,
+                            # Scrapy doesn't pass request to constructor
+                            # request=req2,
                             headers={b'Content-Type': b'application/json'},
                             body=res_body.encode('utf8'))
     response2 = mw.process_response(req2, response, None)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -176,7 +176,12 @@ def test_magic_response():
         'headers': [
             {'name': 'Content-Type', 'value': "text/html"},
             {'name': 'X-My-Header', 'value': "foo"},
-        ]
+            {'name': 'Set-Cookie', 'value': "bar=baz"},
+        ],
+        'cookies': [
+            {'name': 'foo', 'value': 'bar'},
+            {'name': 'session', 'value': '12345', 'path': '/'},
+        ],
     }
     resp = TextResponse("http://mysplash.example.com/execute",
                         headers={b'Content-Type': b'application/json'},
@@ -188,6 +193,7 @@ def test_magic_response():
     assert resp2.headers == {
         b'Content-Type': [b'text/html'],
         b'X-My-Header': [b'foo'],
+        b'Set-Cookie': [b'bar=baz', b'foo=bar', b'session=12345; Path=/'],
     }
     assert resp2.status == 404
     assert resp2.url == "http://exmaple.com/#id42"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -101,7 +101,7 @@ def test_dont_process_response():
     assert resp2 is resp
 
 
-def test_splash_requst_parameters():
+def test_splash_request_parameters():
     mw = _get_mw()
 
     def cb():
@@ -126,6 +126,7 @@ def test_splash_requst_parameters():
         'slot_policy': SlotPolicy.SINGLE_SLOT,
         'splash_headers': {'X-My-Header': 'value'},
         'magic_response': False,
+        'session_id': 'default',
         'args': {
             'url': "http://example.com/#!start",
             'http_method': 'POST',
@@ -193,7 +194,7 @@ def test_magic_response():
     assert resp2.headers == {
         b'Content-Type': [b'text/html'],
         b'X-My-Header': [b'foo'],
-        b'Set-Cookie': [b'bar=baz', b'foo=bar', b'session=12345; Path=/'],
+        b'Set-Cookie': [b'bar=baz'],
     }
     assert resp2.status == 404
     assert resp2.url == "http://exmaple.com/#id42"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -135,6 +135,7 @@ def test_splash_request_parameters():
             "myarg": 3.0,
         },
         magic_response=False,
+        headers={'X-My-Header': 'value'}
     )
     req2 = cookie_mw.process_request(req, None) or req
     req2 = mw.process_request(req2, None)
@@ -152,6 +153,9 @@ def test_splash_request_parameters():
             'cookies': [],
             'lua_source': 'function main() end',
             'myarg': 3.0,
+            'headers': {
+                'X-My-Header': 'value',
+            }
         },
     }
     assert req2.callback == cb
@@ -280,8 +284,10 @@ def test_magic_response():
 def test_magic_response2():
     # check 'body' handling and another 'headers' format
     mw = _get_mw()
-    req = SplashRequest('http://example.com/', magic_response=True)
+    req = SplashRequest('http://example.com/', magic_response=True,
+                        headers={'foo': 'bar'}, dont_send_headers=True)
     req = mw.process_request(req, None)
+    assert 'headers' not in req.meta['splash']['args']
 
     resp_data = {
         'body': base64.b64encode(b"binary data").decode('ascii'),

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -78,6 +78,7 @@ def test_splash_request():
     assert response2.url == req.url
     assert response2.body == b"<html><body>Hello</body></html>"
     assert response2.css("body").extract_first() == "<body>Hello</body>"
+    assert response2.headers == {b'Content-Type': [b'text/html']}
 
     # check .replace method
     response3 = response2.replace(status=404)
@@ -272,6 +273,7 @@ def test_magic_response_caching(tmpdir):
     assert resp3_1.text == "<html><body>Hello</body></html>"
     assert resp3_1.css("body").extract_first() == "<body>Hello</body>"
     assert resp3_1.data['render_time'] == 0.5
+    assert resp3_1.headers[b'Content-Type'] == b'text/html; charset=utf-8'
 
 
 def test_splash_request_no_url():

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -80,6 +80,19 @@ def test_splash_request():
         assert getattr(response3, attr) == getattr(response2, attr)
 
 
+def test_dont_process_response():
+    mw = _get_mw()
+    req = SplashRequest("http://example.com/",
+        endpoint="render.html",
+        dont_process_response=True,
+    )
+    req2 = mw.process_request(req, None)
+    resp = Response("http://example.com/")
+    resp2 = mw.process_response(req2, resp, None)
+    assert resp2.__class__ is Response
+    assert resp2 is resp
+
+
 def test_splash_requst_parameters():
     mw = _get_mw()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from scrapy.http import Headers
+from scrapyjs.utils import headers_to_scrapy
+
+
+def test_headers_to_scrapy():
+    assert headers_to_scrapy(None) == Headers()
+    assert headers_to_scrapy({}) == Headers()
+    assert headers_to_scrapy([]) == Headers()
+
+    html_headers = Headers({'Content-Type': 'text/html'})
+
+    assert headers_to_scrapy({'Content-Type': 'text/html'}) == html_headers
+    assert headers_to_scrapy([('Content-Type', 'text/html')]) == html_headers
+    assert headers_to_scrapy([{'name': 'Content-Type', 'value': 'text/html'}]) == html_headers

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from scrapy.http import Headers
-from scrapyjs.utils import headers_to_scrapy
+from scrapyjs.utils import headers_to_scrapy, cookies_to_header_values
 
 
 def test_headers_to_scrapy():
@@ -15,3 +15,17 @@ def test_headers_to_scrapy():
     assert headers_to_scrapy({'Content-Type': 'text/html'}) == html_headers
     assert headers_to_scrapy([('Content-Type', 'text/html')]) == html_headers
     assert headers_to_scrapy([{'name': 'Content-Type', 'value': 'text/html'}]) == html_headers
+
+
+def test_cookies_to_header_values():
+    assert cookies_to_header_values(None) == []
+    assert cookies_to_header_values([]) == []
+    assert cookies_to_header_values(["foo=bar", "x=y"]) == ["foo=bar", "x=y"]
+    assert cookies_to_header_values([{
+        "name": "TestCookie",
+        "value": "Cookie Value",
+        "path": "/",
+        "domain": "www.janodvarko.cz",
+        "expires": "2009-07-24T19:20:30.123+02:00",
+        "httpOnly": False,
+    }]) == ['TestCookie="Cookie Value"; Domain=www.janodvarko.cz; expires=2009-07-24T19:20:30.123+02:00; Path=/']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from scrapy.http import Headers
-from scrapyjs.utils import headers_to_scrapy, cookies_to_header_values
+from scrapyjs.utils import headers_to_scrapy
 
 
 def test_headers_to_scrapy():
@@ -15,17 +15,3 @@ def test_headers_to_scrapy():
     assert headers_to_scrapy({'Content-Type': 'text/html'}) == html_headers
     assert headers_to_scrapy([('Content-Type', 'text/html')]) == html_headers
     assert headers_to_scrapy([{'name': 'Content-Type', 'value': 'text/html'}]) == html_headers
-
-
-def test_cookies_to_header_values():
-    assert cookies_to_header_values(None) == []
-    assert cookies_to_header_values([]) == []
-    assert cookies_to_header_values(["foo=bar", "x=y"]) == ["foo=bar", "x=y"]
-    assert cookies_to_header_values([{
-        "name": "TestCookie",
-        "value": "Cookie Value",
-        "path": "/",
-        "domain": "www.janodvarko.cz",
-        "expires": "2009-07-24T19:20:30.123+02:00",
-        "httpOnly": False,
-    }]) == ['TestCookie="Cookie Value"; Domain=www.janodvarko.cz; expires=2009-07-24T19:20:30.123+02:00; Path=/']


### PR DESCRIPTION
This PR provides an easier API to process data returned by Splash.

TODO:
- [x] fix saving/loading Splash responses to/from cache;
- [x] magical JSON response handling:
  - [x] set response.headers from 'headers';
  - [x] set response.headers from 'cookies';
  - [x] set response.body either from 'html' or 'body';
  - [x] set response.status from 'http_status';
  - [x] set response.url from 'url.
- ~~add shortcuts to access base64-encoded values (e.g. 'png' / 'jpeg' keys);~~
- [x] re-check that SplashRequest works correctly with persistent request queues: it works, but `__repr__` is lost; see https://github.com/scrapy/scrapy/issues/1890. 
- [x] check how custom Splash responses interact with builtin Scrapy middlewares, esp. when headers are restored from JSON response:
  - [x] RetryMiddleware;
  - [x] AjaxCrawlMiddleware;
  - [x] ChunkedTransferMiddleware;
  - [x] DecompressionMiddleware - not enabled by default;
  - [x] HttpCompressionMiddleware - see https://github.com/scrapy/scrapy/issues/1895;
  - [x] RedirectMiddleware;
  - [x] RobotsTxtMiddleware;
  - [x] RefererMiddleware
- [x] check that examples work;
- [x] allow to handle cookies transparently;
- [x] allow to handle headers transparently;

See https://github.com/scrapy-plugins/scrapy-splash/issues/44, https://github.com/scrapy-plugins/scrapy-splash/issues/14, https://github.com/scrapy-plugins/scrapy-splash/issues/12, https://github.com/scrapy-plugins/scrapy-splash/issues/10, https://github.com/scrapy-plugins/scrapy-splash/issues/8.
