### PR TITLE
Fix for unicode URL (Py2 mostly)

### DIFF
--- a/scrapyjs/request.py
+++ b/scrapyjs/request.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import scrapy
 
 from scrapyjs import SlotPolicy
+from scrapyjs.utils import to_native_str
 
 # XXX: we can't implement SplashRequest without middleware support
 # because there is no way to set Splash URL based on settings
@@ -34,6 +35,7 @@ class SplashRequest(scrapy.Request):
 
         if url is None:
             url = 'about:blank'
+        url = to_native_str(url)
 
         meta = kwargs.pop('meta', {})
         splash_meta = meta.setdefault('splash', {})

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -305,6 +305,23 @@ def test_magic_response2():
     assert resp2.url == "http://example.com/"
 
 
+def test_unicode_url():
+    mw = _get_mw()
+    req = SplashRequest(
+        # note unicode URL
+        u"http://example.com/", endpoint='execute')
+    req2 = mw.process_request(req, None)
+    res = {'html': '<html><body>Hello</body></html>'}
+    res_body = json.dumps(res)
+    response = TextResponse("http://mysplash.example.com/execute",
+                            # Scrapy doesn't pass request to constructor
+                            # request=req2,
+                            headers={b'Content-Type': b'application/json'},
+                            body=res_body.encode('utf8'))
+    response2 = mw.process_response(req2, response, None)
+    assert response2.url == "http://example.com/"
+
+
 def test_magic_response_http_error():
     mw = _get_mw()
     req = SplashRequest('http://example.com/foo')


### PR DESCRIPTION
Request constructor normalizes it's url to a native string, but Response just expects url to be a native string, so it is important to make url in splash args a native string too, else it will explode in Response constructor later.

Another possible place to fix it is in the `Response.__init__`, but this felt more in-line with scrapy approach.
