### PR TITLE
Do not fail on meta=None in SplashRequest

### DIFF
--- a/scrapyjs/request.py
+++ b/scrapyjs/request.py
@@ -31,13 +31,14 @@ class SplashRequest(scrapy.Request):
                  magic_response=True,
                  session_id='default',
                  http_status_from_error_code=True,
+                 meta=None,
                  **kwargs):
 
         if url is None:
             url = 'about:blank'
         url = to_native_str(url)
 
-        meta = kwargs.pop('meta', {})
+        meta = meta or {}
         splash_meta = meta.setdefault('splash', {})
         splash_meta.setdefault('endpoint', endpoint)
         splash_meta.setdefault('slot_policy', slot_policy)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,7 @@
+from scrapyjs import SplashRequest
+
+
+def test_meta_None():
+    req1 = SplashRequest('http://example.com')
+    req2 = SplashRequest('http://example.com', meta=None)
+    assert req1.meta == req2.meta


### PR DESCRIPTION
scrapy.Request accepts meta as None, this can be convenient when writing wrappers around SplashRequest
