### PR TITLE
UTC time both in har_to_cookie and in cookie_to_har

### DIFF
--- a/scrapyjs/cookies.py
+++ b/scrapyjs/cookies.py
@@ -97,7 +97,7 @@ def cookie_to_har(cookie):
         c['domain'] = cookie.domain
 
     if cookie.expires:
-        tm = time.localtime(cookie.expires)
+        tm = time.gmtime(cookie.expires)
         c['expires'] = time.strftime("%Y-%m-%dT%H:%M:%SZ", tm)
 
     http_only = cookie.get_nonstandard_attr('HttpOnly')

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,0 +1,20 @@
+from scrapyjs.cookies import har_to_cookie, cookie_to_har
+
+
+# See also doctests in scrapyjs.cookies module
+
+
+def test_cookie_to_har():
+    har_cookie =  {
+        "name": "TestCookie",
+        "value": "Cookie Value",
+        "path": "/foo",
+        "domain": "www.janodvarko.cz",
+        "expires": "2009-07-24T19:20:30Z",
+        "httpOnly": True,
+        "secure": True,
+        "comment": "this is a test"
+    }
+    assert cookie_to_har(har_to_cookie(har_cookie)) == har_cookie
+    cookie = har_to_cookie(har_cookie)
+    assert vars(cookie) == vars(har_to_cookie(cookie_to_har(cookie)))


### PR DESCRIPTION
Without this, different timezones might be used, and `cookie_to_har(har_to_cookie(har_cookie))` will have a different `expires` value. Python cookie docs are not very clear about the timezone used, though.
