### PR TITLE
Removing cookies

### DIFF
--- a/scrapyjs/cookies.py
+++ b/scrapyjs/cookies.py
@@ -28,7 +28,10 @@ def har_to_jar(cookiejar, har_cookies, request_cookies=None):
             cookie = har_to_cookie(c)
             if _cookie_key(cookie) not in har_cookie_keys:
                 # We sent it but it did not come back: remove it
-                cookiejar.clear(cookie.domain, cookie.path, cookie.name)
+                try:
+                    cookiejar.clear(cookie.domain, cookie.path, cookie.name)
+                except KeyError:
+                    pass  # It could have been already removed
 
 
 def _cookie_key(cookie):

--- a/scrapyjs/cookies.py
+++ b/scrapyjs/cookies.py
@@ -14,10 +14,25 @@ def jar_to_har(cookiejar):
     return [cookie_to_har(c) for c in cookiejar]
 
 
-def har_to_jar(cookiejar, har_cookies):
-    """ Add HAR cookies to the cookiejar """
+def har_to_jar(cookiejar, har_cookies, request_cookies=None):
+    """ Add HAR cookies to the cookiejar.
+    If request_cookies is given, remove cookies absent from har_cookies
+    but present in request_cookies (they were removed). """
+    har_cookie_keys = set()
     for c in har_cookies:
-        cookiejar.set_cookie(har_to_cookie(c))
+        cookie = har_to_cookie(c)
+        cookiejar.set_cookie(cookie)
+        har_cookie_keys.add(_cookie_key(cookie))
+    if request_cookies:
+        for c in request_cookies:
+            cookie = har_to_cookie(c)
+            if _cookie_key(cookie) not in har_cookie_keys:
+                # We sent it but it did not come back: remove it
+                cookiejar.clear(cookie.domain, cookie.path, cookie.name)
+
+
+def _cookie_key(cookie):
+    return (cookie.domain, cookie.path, cookie.name)
 
 
 def har_to_cookie(har_cookie):

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -88,7 +88,9 @@ class SplashCookiesMiddleware(object):
             return response
 
         jar = self.jars[session_id]
-        har_to_jar(jar, response.data['cookies'])
+        request_cookies = request.meta['_splash_processed']['args']\
+                          .get('cookies', [])
+        har_to_jar(jar, response.data['cookies'], request_cookies)
         response.cookiejar = jar
         return response
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -259,7 +259,7 @@ def test_magic_response():
         ],
         'cookies': [
             {'name': 'egg', 'value': 'spam'},
-            {'name': 'foo', 'value': ''},
+           #{'name': 'foo', 'value': ''},  -- this won't be in response
             {'name': 'session', 'value': '12345', 'path': '/',
              'expires': '2056-07-24T19:20:30Z'},
         ],

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -212,6 +212,7 @@ def test_magic_response():
             {'name': 'Set-Cookie', 'value': "bar=baz"},
         ],
         'cookies': [
+            {'name': 'foo', 'value': 'bar'},
             {'name': 'bar', 'value': 'baz', 'domain': '.example.com'},
             {'name': 'session', 'value': '12345', 'path': '/',
              'expires': '2055-07-24T19:20:30Z'},
@@ -258,7 +259,9 @@ def test_magic_response():
             {'name': 'Set-Cookie', 'value': "bar=baz"},
         ],
         'cookies': [
+            {'name': 'spam', 'value': 'ham'},
             {'name': 'egg', 'value': 'spam'},
+            {'name': 'bar', 'value': 'baz', 'domain': '.example.com'},
            #{'name': 'foo', 'value': ''},  -- this won't be in response
             {'name': 'session', 'value': '12345', 'path': '/',
              'expires': '2056-07-24T19:20:30Z'},
@@ -272,12 +275,10 @@ def test_magic_response():
     assert isinstance(resp2, scrapyjs.SplashJsonResponse)
     assert resp2.data == resp_data
     cookies = [c for c in resp2.cookiejar]
-    assert {c.name for c in cookies} == {'foo', 'session', 'egg', 'bar', 'spam'}
+    assert {c.name for c in cookies} == {'session', 'egg', 'bar', 'spam'}
     for c in cookies:
         if c.name == 'session':
             assert c.expires == 2731692030
-        if c.name == 'foo':
-            assert c.value == ''
         if c.name == 'spam':
             assert c.value == 'ham'
 


### PR DESCRIPTION
Should fix #52. Now response cookies are compared with request cookies. I added a test for concurrent requests (for a problem from #54).
