### PR TITLE
store a flag in meta['_splash_processed'], not a meta['splash'] copy

### DIFF
--- a/scrapy_splash/middleware.py
+++ b/scrapy_splash/middleware.py
@@ -83,8 +83,7 @@ class SplashCookiesMiddleware(object):
             return response
 
         if not request.meta.get('_splash_processed'):
-            warnings.warn("SplashCookiesMiddleware must have lower priority "
-                          "than SplashMiddleware")
+            warnings.warn("SplashCookiesMiddleware requires SplashMiddleware")
             return response
 
         splash_options = request.meta['splash']

--- a/scrapy_splash/request.py
+++ b/scrapy_splash/request.py
@@ -73,7 +73,7 @@ class SplashRequest(scrapy.Request):
 
     @property
     def _processed(self):
-        return '_splash_processed' in self.meta
+        return self.meta.get('_splash_processed')
 
     @property
     def _splash_args(self):

--- a/scrapy_splash/response.py
+++ b/scrapy_splash/response.py
@@ -45,7 +45,7 @@ class _SplashResponseMixin(object):
     def _splash_options(self, request=None):
         if request is None:
             request = self.request
-        return request.meta.get("_splash_processed", {})
+        return request.meta.get("splash", {})
 
     def _splash_args(self, request=None):
         return self._splash_options(request).get('args', {})


### PR DESCRIPTION
`_splash_processed` dict was pointless because all changes to it reflected in `meta`, it was not even a shallow copy. Storing Splash arguments only once is more efficient when disk queues are used.
