### PR TITLE
more efficient handling of duplicate args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -508,7 +508,7 @@ Note how are arguments passed to the script::
 
 
 Use a Lua script to get an HTML response with cookies, headers, body
-and method set to correct values; ``lua_script`` argument value is cached
+and method set to correct values; ``lua_source`` argument value is cached
 on Splash server and is not sent with each request (it requires Splash 2.1+)::
 
     import scrapy

--- a/example/scrashtest/settings.py
+++ b/example/scrashtest/settings.py
@@ -13,6 +13,10 @@ DOWNLOADER_MIDDLEWARES = {
     # Downloader side
 }
 
-SPLASH_URL = 'http://192.168.59.103:8050/'
+SPIDER_MIDDLEWARES = {
+    'scrapy_splash.SplashDeduplicateArgsMiddleware': 100,
+}
+SPLASH_URL = 'http://127.0.0.1:8050/'
+# SPLASH_URL = 'http://192.168.59.103:8050/'
 DUPEFILTER_CLASS = 'scrapy_splash.SplashAwareDupeFilter'
 HTTPCACHE_STORAGE = 'scrapy_splash.SplashAwareFSCacheStorage'

--- a/example/scrashtest/spiders/dmoz.py
+++ b/example/scrashtest/spiders/dmoz.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
-
 import scrapy
 from scrapy.linkextractors import LinkExtractor
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+doctest_optionflags = NORMALIZE_WHITESPACE ALLOW_UNICODE

--- a/scrapy_splash/__init__.py
+++ b/scrapy_splash/__init__.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from .middleware import SplashMiddleware, SlotPolicy, SplashCookiesMiddleware
+from .middleware import (
+    SplashMiddleware,
+    SplashCookiesMiddleware,
+    SplashDeduplicateArgsMiddleware,
+    SlotPolicy,
+)
 from .dupefilter import SplashAwareDupeFilter, splash_request_fingerprint
 from .cache import SplashAwareFSCacheStorage
 from .response import SplashResponse, SplashTextResponse, SplashJsonResponse

--- a/scrapy_splash/middleware.py
+++ b/scrapy_splash/middleware.py
@@ -115,7 +115,7 @@ class SplashMiddleware(object):
     default_endpoint = "render.json"
     splash_extra_timeout = 5.0
     default_policy = SlotPolicy.PER_DOMAIN
-    priority_adjust = +5
+    rescheduling_priority_adjust = +20
 
     def __init__(self, crawler, splash_base_url, slot_policy, log_400):
         self.crawler = crawler
@@ -208,7 +208,7 @@ class SplashMiddleware(object):
             method='POST',
             body=body,
             headers=headers,
-            priority=request.priority + self.priority_adjust
+            priority=request.priority + self.rescheduling_priority_adjust
         )
         self.crawler.stats.inc_value('splash/%s/request_count' % endpoint)
         return new_request

--- a/scrapy_splash/request.py
+++ b/scrapy_splash/request.py
@@ -32,6 +32,7 @@ class SplashRequest(scrapy.Request):
                  magic_response=True,
                  session_id='default',
                  http_status_from_error_code=True,
+                 cache_args=None,
                  meta=None,
                  **kwargs):
 
@@ -55,6 +56,8 @@ class SplashRequest(scrapy.Request):
             splash_meta['dont_send_headers'] = True
         if http_status_from_error_code:
             splash_meta['http_status_from_error_code'] = True
+        if cache_args is not None:
+            splash_meta['cache_args'] = cache_args
 
         if session_id is not None:
             if splash_meta['endpoint'].strip('/') == 'execute':

--- a/scrapy_splash/utils.py
+++ b/scrapy_splash/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import json
 import hashlib
 import six
 
@@ -45,6 +46,12 @@ def dict_hash(obj, start=''):
     return h.hexdigest()
 
 
+def json_based_hash(value):
+    """ Return a hash for any JSON-serializable value """
+    v = json.dumps(value, sort_keys=True, ensure_ascii=False).encode('utf8')
+    return hashlib.sha1(v).hexdigest()
+
+
 def headers_to_scrapy(headers):
     """
     Return scrapy.http.Headers instance from headers data.
@@ -75,3 +82,25 @@ def scrapy_headers_to_unicode_dict(headers):
         to_unicode(key): to_unicode(b','.join(value))
         for key, value in headers.items()
     }
+
+
+def parse_x_splash_saved_arguments_header(value):
+    """
+    Parse X-Splash-Saved-Arguments header value.
+
+    >>> value = u"name1=9a6747fc6259aa374ab4e1bb03074b6ec672cf99;name2=ba001160ef96fe2a3f938fea9e6762e204a562b3"
+    >>> dct = parse_x_splash_saved_arguments_header(value)
+    >>> sorted(list(dct.keys()))
+    ['name1', 'name2']
+    >>> dct['name1']
+    '9a6747fc6259aa374ab4e1bb03074b6ec672cf99'
+    >>> dct['name2']
+    'ba001160ef96fe2a3f938fea9e6762e204a562b3'
+
+    Binary header values are also supported:
+    >>> dct2 = parse_x_splash_saved_arguments_header(value.encode('utf8'))
+    >>> dct2 == dct
+    True
+    """
+    value = to_unicode(value)
+    return dict(kv.split('=', 1) for kv in  value.split(";"))

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -490,7 +490,9 @@ def test_cache_args():
     req, = list(dedupe_mw.process_start_requests([req], spider))
     # ----> scheduler
     assert req.meta['splash']['args']['lua_source'] != lua_source
-    assert list(spider.state[SplashDeduplicateArgsMiddleware.state_key].values()) == [lua_source]
+    state = spider.state[SplashDeduplicateArgsMiddleware.state_key]
+    assert list(state.values()) == [lua_source]
+    assert list(state.keys()) == [req.meta['splash']['args']['lua_source']]
     # <---- scheduler
     # process request before sending it to the downloader
     req = mw.process_request(req, spider) or req


### PR DESCRIPTION
This PR adds a new feature: user can specify which Splash arguments don't change often, and scrapy-splash will handle them more efficiently: 
- [x] they won't be stored in disk queue multiple times;
- [x] they won't be sent to Splash multiple times (requires https://github.com/scrapinghub/splash/pull/442)
