### PR TITLE
Faster fingerprints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ scrapy_splash.egg-info
 .coverage
 .scrapy
 htmlcov
+.hypothesis
+.ipynb_checkpoints

--- a/scrapy_splash/middleware.py
+++ b/scrapy_splash/middleware.py
@@ -19,7 +19,7 @@ from scrapy_splash.responsetypes import responsetypes
 from scrapy_splash.cookies import jar_to_har, har_to_jar
 from scrapy_splash.utils import (
     scrapy_headers_to_unicode_dict,
-    json_based_hash,
+    fast_hash,
     parse_x_splash_saved_arguments_header,
 )
 
@@ -162,7 +162,7 @@ class SplashDeduplicateArgsMiddleware(object):
             if name not in args:
                 continue
             value = args[name]
-            fp = 'LOCAL+' + json_based_hash(value)
+            fp = 'LOCAL+' + fast_hash(value)
             args[name] = fp
             spider.state[self.state_key][fp] = value
             request.meta['splash']['_replaced_args'].append(name)

--- a/scrapy_splash/middleware.py
+++ b/scrapy_splash/middleware.py
@@ -19,7 +19,7 @@ from scrapy_splash.responsetypes import responsetypes
 from scrapy_splash.cookies import jar_to_har, har_to_jar
 from scrapy_splash.utils import (
     scrapy_headers_to_unicode_dict,
-    fast_hash,
+    json_based_hash,
     parse_x_splash_saved_arguments_header,
 )
 
@@ -162,9 +162,9 @@ class SplashDeduplicateArgsMiddleware(object):
             if name not in args:
                 continue
             value = args[name]
-            fp = 'LOCAL+' + fast_hash(value)
-            args[name] = fp
+            fp = 'LOCAL+' + json_based_hash(value)
             spider.state[self.local_values_key][fp] = value
+            args[name] = fp
             request.meta['splash']['_replaced_args'].append(name)
 
         return request

--- a/scrapy_splash/utils.py
+++ b/scrapy_splash/utils.py
@@ -56,14 +56,31 @@ def _process(value):
     return value
 
 
-def fast_hash(value):
+def _fast_hash(value):
     """
     Return a hash for any JSON-serializable value.
     Hash is not guaranteed to be the same in different Python processes,
     but it is very fast to compute for data structures with large string
     values.
     """
-    value = _process(value)
+    return _json_based_hash(_process(value))
+
+
+_hash_cache = {}  # fast hash => hash
+def json_based_hash(value):
+    """
+    Return a hash for any JSON-serializable value.
+
+    >>> json_based_hash({"foo": "bar", "baz": [1, 2]})
+    'c15a6b4b2d125398b00264fc346d1e1817ba8522'
+    """
+    fp = _fast_hash(value)
+    if fp not in _hash_cache:
+        _hash_cache[fp] = _json_based_hash(value)
+    return _hash_cache[fp]
+
+
+def _json_based_hash(value):
     v = json.dumps(value, sort_keys=True, ensure_ascii=False).encode('utf8')
     return hashlib.sha1(v).hexdigest()
 

--- a/scrapy_splash/utils.py
+++ b/scrapy_splash/utils.py
@@ -53,7 +53,7 @@ def _process(value, sha=False):
         return 'h', hash(value)
     if isinstance(value, dict):
         return {_process(k, sha=True): _process(v, sha) for k, v in value.items()}
-    if isinstance(value, (list, tuple, set, frozenset)):
+    if isinstance(value, (list, tuple)):
         return [_process(v, sha) for v in value]
     return value
 

--- a/scrapy_splash/utils.py
+++ b/scrapy_splash/utils.py
@@ -46,8 +46,24 @@ def dict_hash(obj, start=''):
     return h.hexdigest()
 
 
-def json_based_hash(value):
-    """ Return a hash for any JSON-serializable value """
+def _process(value):
+    if isinstance(value, (six.text_type, bytes)):
+        return 'h', hash(value)
+    if isinstance(value, dict):
+        return {k: _process(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_process(v) for v in value]
+    return value
+
+
+def fast_hash(value):
+    """
+    Return a hash for any JSON-serializable value.
+    Hash is not guaranteed to be the same in different Python processes,
+    but it is very fast to compute for data structures with large string
+    values.
+    """
+    value = _process(value)
     v = json.dumps(value, sort_keys=True, ensure_ascii=False).encode('utf8')
     return hashlib.sha1(v).hexdigest()
 

--- a/scrapy_splash/utils.py
+++ b/scrapy_splash/utils.py
@@ -46,13 +46,15 @@ def dict_hash(obj, start=''):
     return h.hexdigest()
 
 
-def _process(value):
+def _process(value, sha=False):
     if isinstance(value, (six.text_type, bytes)):
+        if sha:
+            return hashlib.sha1(to_bytes(value)).hexdigest()
         return 'h', hash(value)
     if isinstance(value, dict):
-        return {k: _process(v) for k, v in value.items()}
+        return {_process(k, sha=True): _process(v, sha) for k, v in value.items()}
     if isinstance(value, (list, tuple, set, frozenset)):
-        return [_process(v) for v in value]
+        return [_process(v, sha) for v in value]
     return value
 
 
@@ -72,11 +74,11 @@ def json_based_hash(value):
     Return a hash for any JSON-serializable value.
 
     >>> json_based_hash({"foo": "bar", "baz": [1, 2]})
-    'c15a6b4b2d125398b00264fc346d1e1817ba8522'
+    '0570066939bea46c610bfdc35b20f37ef09d05ed'
     """
     fp = _fast_hash(value)
     if fp not in _hash_cache:
-        _hash_cache[fp] = _json_based_hash(value)
+        _hash_cache[fp] = _json_based_hash(_process(value, sha=True))
     return _hash_cache[fp]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import json
 
+from hypothesis import given, assume
+from hypothesis import strategies as st
 from scrapy.http import Headers
-from scrapy_splash.utils import headers_to_scrapy
+from scrapy_splash.utils import headers_to_scrapy, fast_hash
 
 
 def test_headers_to_scrapy():
@@ -15,3 +18,26 @@ def test_headers_to_scrapy():
     assert headers_to_scrapy({'Content-Type': 'text/html'}) == html_headers
     assert headers_to_scrapy([('Content-Type', 'text/html')]) == html_headers
     assert headers_to_scrapy([{'name': 'Content-Type', 'value': 'text/html'}]) == html_headers
+
+
+_primitive = st.floats() | st.booleans() | st.text() | st.none() | st.integers()
+_data = st.recursive(_primitive,
+    lambda children: (
+        children |
+        st.lists(children) |
+        st.tuples(children) |
+        st.dictionaries(st.text(), children) |
+        st.tuples(st.just('h'), children)
+    ),
+    max_leaves=5,
+)
+
+
+@given(_data, _data)
+def test_fast_hash_different(val1, val2):
+    def _dump(v):
+        return json.dumps(v, sort_keys=True)
+    assume(_dump(val1) != _dump(val2))
+    assert fast_hash(val1) == fast_hash(val1)
+    assert fast_hash(val1) != fast_hash(val2)
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import json
 from hypothesis import given, assume
 from hypothesis import strategies as st
 from scrapy.http import Headers
-from scrapy_splash.utils import headers_to_scrapy, fast_hash
+from scrapy_splash.utils import headers_to_scrapy, _fast_hash, json_based_hash
 
 
 def test_headers_to_scrapy():
@@ -34,10 +34,16 @@ _data = st.recursive(_primitive,
 
 
 @given(_data, _data)
-def test_fast_hash_different(val1, val2):
+def test_fast_hash(val1, val2):
     def _dump(v):
         return json.dumps(v, sort_keys=True)
     assume(_dump(val1) != _dump(val2))
-    assert fast_hash(val1) == fast_hash(val1)
-    assert fast_hash(val1) != fast_hash(val2)
+    assert _fast_hash(val1) == _fast_hash(val1)
+    assert _fast_hash(val1) != _fast_hash(val2)
 
+
+@given(_data, _data)
+def test_json_based_hash(val1, val2):
+    assume(val1 != val2)
+    assert json_based_hash(val1) == json_based_hash(val1)
+    assert json_based_hash(val1) != json_based_hash(val2)

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ deps =
     -rrequirements.txt
     pytest
     pytest-cov
+    hypothesis
+    hypothesis-pytest
 commands =
     pip install -e .
     py.test --doctest-modules --cov=scrapy_splash {posargs:scrapy_splash tests}
@@ -21,6 +23,8 @@ deps =
     -rrequirements-py3.txt
     pytest
     pytest-cov
+    hypothesis
+    hypothesis-pytest
 
 [testenv:py34]
 basepython = python3.4


### PR DESCRIPTION
This should fix #65.

For a nested dict with 30Kb string value `_fast_hash` is about 3-4x faster than `_json_based_hash(_process(value, sha=True))`, and the latter is about 3-4x faster than `_json_based_hash(value)`. Because with `cache_args` it is expected to have a very large amount of duplicates I went with this complicated solution.
