### PR TITLE
Make SplashCookiesMiddleware accept COOKIES_DEBUG

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,23 @@ Configuration
     could change in future.
 
 
+There are also some additional options available.
+Put them into your ``settings.py`` if you want to change the defaults:
+
+* ``SPLASH_COOKIES_DEBUG`` is ``False`` by default.
+  Set to ``True`` to enable debugging cookies in the ``SplashCookiesMiddleware``.
+  This option is similar to ``COOKIES_DEBUG``
+  for the built-in scarpy cookies middleware: it logs sent and received cookies
+  for all requests.
+* ``SPLASH_LOG_400`` is ``True`` by default - it instructs to log all 400 errors
+  from Splash. They are important because they show errors occurred
+  when executing the Splash script. Set it to ``False`` to disable this logging.
+* ``SPLASH_SLOT_POLICY`` is ``scrapy_splash.SlotPolicy.PER_DOMAIN`` by default.
+  It specifies how concurrency & politeness are maintained for Splash requests,
+  and specify the default value for ``slot_policy`` argument for
+  ``SplashRequest``, which is described below.
+
+
 Usage
 =====
 

--- a/scrapy_splash/middleware.py
+++ b/scrapy_splash/middleware.py
@@ -52,7 +52,7 @@ class SplashCookiesMiddleware(object):
 
     @classmethod
     def from_crawler(cls, crawler):
-        return cls(debug=crawler.settings.getbool('COOKIES_DEBUG'))
+        return cls(debug=crawler.settings.getbool('SPLASH_COOKIES_DEBUG'))
 
     def process_request(self, request, spider):
         """

--- a/scrapy_splash/middleware.py
+++ b/scrapy_splash/middleware.py
@@ -78,9 +78,9 @@ class SplashCookiesMiddleware(object):
 
         cookies = self._get_request_cookies(request)
         har_to_jar(jar, cookies)
-        self._debug_cookie(request, spider)
 
         splash_args['cookies'] = jar_to_har(jar)
+        self._debug_cookie(request, spider)
 
     def process_response(self, request, response, spider):
         """
@@ -123,21 +123,25 @@ class SplashCookiesMiddleware(object):
 
     def _debug_cookie(self, request, spider):
         if self.debug:
-            cl = [to_native_str(c, errors='replace')
-                  for c in request.headers.getlist('Cookie')]
+            cl = request.meta['splash']['args']['cookies']
             if cl:
-                cookies = "\n".join("Cookie: {}\n".format(c) for c in cl)
-                msg = "Sending cookies to: {}\n{}".format(request, cookies)
+                cookies = '\n'.join(
+                    'Cookie: {}'.format(self._har_repr(c)) for c in cl)
+                msg = 'Sending cookies to: {}\n{}'.format(request, cookies)
                 logger.debug(msg, extra={'spider': spider})
 
     def _debug_set_cookie(self, response, spider):
         if self.debug:
-            cl = [to_native_str(c, errors='replace')
-                  for c in response.headers.getlist('Set-Cookie')]
+            cl = response.data['cookies']
             if cl:
-                cookies = "\n".join("Set-Cookie: {}\n".format(c) for c in cl)
-                msg = "Received cookies from: {}\n{}".format(response, cookies)
+                cookies = '\n'.join(
+                    'Set-Cookie: {}'.format(self._har_repr(c)) for c in cl)
+                msg = 'Received cookies from: {}\n{}'.format(response, cookies)
                 logger.debug(msg, extra={'spider': spider})
+
+    @staticmethod
+    def _har_repr(har_cookie):
+        return '{}={}'.format(har_cookie['name'], har_cookie['value'])
 
 
 class SplashDeduplicateArgsMiddleware(object):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -38,7 +38,7 @@ def _get_mw():
 
 
 def _get_cookie_mw():
-    return SplashCookiesMiddleware()
+    return SplashCookiesMiddleware(debug=True)
 
 
 def test_nosplash():


### PR DESCRIPTION
.. to behave like scrapy CookiesMiddleware. This can be useful for debugging.

Debug methods are copied from it. It would be possible to inherit from it and use the methods from the parent class, but this would be more confusing perhaps.

I though about a good place to mention it in the docs, but could not find it (and maybe it's not significant enough for a special mention).
