### PR TITLE
Do not convert TextResponse to SplashResponse

### DIFF
--- a/scrapy_splash/middleware.py
+++ b/scrapy_splash/middleware.py
@@ -13,6 +13,7 @@ from six.moves.http_cookiejar import CookieJar
 import scrapy
 from scrapy.exceptions import NotConfigured
 from scrapy.http.headers import Headers
+from scrapy.http.response.text import TextResponse
 from scrapy import signals
 
 from scrapy_splash.responsetypes import responsetypes
@@ -399,6 +400,12 @@ class SplashMiddleware(object):
             # downloader middlewares are executed. Here it is set earlier.
             # Does it have any negative consequences?
             respcls = responsetypes.from_args(headers=response.headers)
+            if isinstance(response, TextResponse) and respcls is SplashResponse:
+                # Even if the headers say it's binary, it has already
+                # been detected as a text response by scrapy (for example
+                # because it was decoded successfully), so we should not
+                # convert it to SplashResponse.
+                respcls = SplashTextResponse
             response = response.replace(cls=respcls, request=request)
         return response
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -406,6 +406,22 @@ def test_magic_response_http_error():
     assert resp.url == "http://example.com/foo"
 
 
+def test_change_response_class():
+    mw = _get_mw()
+    req = SplashRequest('http://example.com/', magic_response=True)
+    req = mw.process_request(req, None)
+    # Such response can come when downloading a file, or returning splash:html()
+    resp = TextResponse('http://mysplash.example.com/execute',
+                        headers={b'Content-Type': b'application/pdf'},
+                        body=b'ascii binary data',
+                        encoding='utf-8')
+    resp2 = mw.process_response(req, resp, None)
+    assert isinstance(resp2, TextResponse)
+    assert resp2.url == 'http://example.com/'
+    assert resp2.headers == {b'Content-Type': [b'application/pdf']}
+    assert resp2.body == b'ascii binary data'
+
+
 def test_magic_response_caching(tmpdir):
     # prepare middlewares
     spider = scrapy.Spider(name='foo')

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -406,11 +406,13 @@ def test_magic_response_http_error():
     assert resp.url == "http://example.com/foo"
 
 
-def test_change_response_class():
+def test_change_response_class_to_text():
     mw = _get_mw()
     req = SplashRequest('http://example.com/', magic_response=True)
     req = mw.process_request(req, None)
-    # Such response can come when downloading a file, or returning splash:html()
+    # Such response can come when downloading a file,
+    # or returning splash:html(): the headers say it's binary,
+    # but it can be decoded so it becomes a TextResponse.
     resp = TextResponse('http://mysplash.example.com/execute',
                         headers={b'Content-Type': b'application/pdf'},
                         body=b'ascii binary data',


### PR DESCRIPTION
Do not convert TextResponse to SplashResponse, convert it to SplashTextResponse instead. Detection of response type by content-type is still needed, because this is how we create SplashJsonResponse. I also added a test in dc37d4a that checks that it does not lead to bad results if we get a non-decodable response from some website with json content-type.

Fixes #107