### PR TITLE
note that SPLASH_SLOT_POLICY value isn't a string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Put them into your ``settings.py`` if you want to change the defaults:
 * ``SPLASH_LOG_400`` is ``True`` by default - it instructs to log all 400 errors
   from Splash. They are important because they show errors occurred
   when executing the Splash script. Set it to ``False`` to disable this logging.
-* ``SPLASH_SLOT_POLICY`` is ``scrapy_splash.SlotPolicy.PER_DOMAIN`` by default.
+* ``SPLASH_SLOT_POLICY`` is ``scrapy_splash.SlotPolicy.PER_DOMAIN`` (as object, not just a string) by default.
   It specifies how concurrency & politeness are maintained for Splash requests,
   and specify the default value for ``slot_policy`` argument for
   ``SplashRequest``, which is described below.


### PR DESCRIPTION
Put a little note about what value should `SPLASH_SLOT_POLICY` setting have.

I want this moment to be noted in `README.rst` because it's a little confusing at first, when you need to import something in `settings.py` while Scrapy needs only string paths to mentioned objects.
I think it would be better to refactor how plugin processes settings to import needed object itself, but not inside `settings.py` to keep Scrapy's style.