### PR TITLE
Do not try to decode body of Response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ scrapy_splash.egg-info
 htmlcov
 .hypothesis
 .ipynb_checkpoints
+.pytest_cache

--- a/README.rst
+++ b/README.rst
@@ -315,8 +315,8 @@ SplashJsonResponse provide extra features:
 
   * response.headers are filled from 'headers' keys;
   * response.url is set to the value of 'url' key;
-  * response.body is set to the value of 'html' key,
-    or to base64-decoded value of 'body' key;
+  * response.body is set to the value of 'html' key, utf-8 text expected,
+    or to base64-decoded binary value of 'body' key;
   * response.status is set to the value of 'http_status' key.
     When ``meta['splash']['http_status_from_error_code']`` is True
     and ``assert(splash:go(..))`` fails with an HTTP error

--- a/README.rst
+++ b/README.rst
@@ -260,19 +260,8 @@ to set ``meta['splash']['args']`` use ``SplashRequest(..., args=myargs)``.
 
 * ``meta['splash']['magic_response']`` - when set to True and a JSON
   response is received from Splash, several attributes of the response
-  (headers, body, url, status code) are filled using data returned in JSON:
-
-  * response.headers are filled from 'headers' keys;
-  * response.url is set to the value of 'url' key;
-  * response.body is set to the value of 'html' key,
-    or to base64-decoded value of 'body' key;
-  * response.status is set to the value of 'http_status' key.
-    When ``meta['splash']['http_status_from_error_code']`` is True
-    and ``assert(splash:go(..))`` fails with an HTTP error
-    response.status is also set to HTTP error code.
-
-  Original URL, status and headers are available as ``response.real_url``,
-  ``response.splash_response_status`` and ``response.splash_response_headers``.
+  (headers, body, url, status code) are filled using data returned in JSON,
+  for details see Responses section
 
   This option is set to True by default if you use SplashRequest.
   ``render.json`` and ``execute`` endpoints may not have all the necessary

--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,13 @@ SplashJsonResponse provide extra features:
   * response.url is set to the value of 'url' key;
   * response.body is set to the value of 'html' key,
     or to base64-decoded value of 'body' key;
-  * response.status is set from the value of 'http_status' key.
+  * response.status is set to the value of 'http_status' key.
+    When ``meta['splash']['http_status_from_error_code']`` is True
+    and ``assert(splash:go(..))`` fails with an HTTP error
+    response.status is also set to HTTP error code.
+
+  Original URL, status and headers are available as ``response.real_url``,
+  ``response.splash_response_status`` and ``response.splash_response_headers``.
 
 When ``response.body`` is updated in SplashJsonResponse
 (either from 'html' or from 'body' keys) familiar ``response.css``

--- a/scrapy_splash/response.py
+++ b/scrapy_splash/response.py
@@ -176,7 +176,6 @@ class SplashJsonResponse(SplashResponse):
         # response.body
         if 'body' in self.data:
             self._body = base64.b64decode(self.data['body'])
-            self._cached_ubody = self._body.decode(self.encoding)
         elif 'html' in self.data:
             self._cached_ubody = self.data['html']
             self._body = self._cached_ubody.encode(self.encoding)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -286,6 +286,22 @@ def test_magic_response():
         if c.name == 'spam':
             assert c.value == 'ham'
 
+    resp_data = {
+        'url': "http://exmaple.com/#id42",
+        'body': base64.b64encode(b'\xad').decode('ascii'),
+        'headers': [
+            {'name': 'Content-Type', 'value': "text/html; charset=cp1251"},
+        ]
+    }
+    resp = TextResponse("http://mysplash.example.com/execute",
+                        headers={b'Content-Type': b'application/json'},
+                        body=json.dumps(resp_data).encode('utf8'))
+
+    try:
+        resp2 = mw.process_response(req, resp, None)
+    except:
+        assert 'process_response raised exception' is None
+
 
 def test_cookies():
     mw = _get_mw()


### PR DESCRIPTION
After discussion in https://github.com/scrapy-plugins/scrapy-splash/pull/173
Decoding body of Response using only utf-8 is right way to fail. It is better to skip decoding at all.

There is two problems with integration tests at this moment - https://github.com/scrapy/scrapy/pull/3210#issuecomment-380840192 and https://github.com/scrapy/scrapy/pull/3210#issuecomment-380840192 . Considering this, no integration tests added

Fixing Integration tests requires effort separate from proposed changes