### PR TITLE
Version bump for 0.8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-0.8.0 (2019-07-NN)
+0.8.0 (2021-10-04)
 ------------------
 
 *   Responses now expose the HTTP status code and headers from Splash as

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,34 @@
 Changes
 =======
 
+0.8.0 (2019-07-NN)
+------------------
+
+*   Responses now expose the HTTP status code and headers from Splash as
+    ``response.splash_response_status`` and
+    ``response.splash_response_headers`` (#158)
+
+*   The ``meta`` argument passed to the ``scrapy_splash.request.SplashRequest``
+    constructor is no longer modified (#164)
+
+*   Website responses with 400 or 498 as HTTP status code are no longer
+    handled as the equivalent Splash responses (#158)
+
+*   Cookies are no longer sent to Splash itself (#156)
+
+*   ``scrapy_splash.utils.dict_hash`` now also works with ``obj=None``
+    (``225793b``)
+
+*   Our test suite now includes integration tests (#156) and tests can be run
+    in parallel (``6fb8c41``)
+
+*   There’s a new ‘Getting help’ section in the ``README.rst`` file (#161,
+    #162), the documentation about ``SPLASH_SLOT_POLICY`` has been improved
+    (#157) and a typo as been fixed (#121)
+
+*   Made some internal improvements (``ee5000d``, ``25de545``, ``2aaa79d``)
+
+
 0.7.2 (2017-03-30)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='scrapy-splash',
-    version='0.7.2',
+    version='0.8.0',
     url='https://github.com/scrapy-plugins/scrapy-splash',
     description='JavaScript support for Scrapy using Splash',
     long_description=open('README.rst').read() + "\n\n" + open("CHANGES.rst").read(),


### PR DESCRIPTION
Covers commits until https://github.com/scrapy-plugins/scrapy-splash/commit/e40ca4f3b367ab463273bee1357d3edfe0601f0d

I assumed 0.8.0 (instead of 0.7.3) because there is a (backward-compatible) API change.