### PR TITLE
Test cookie.path_specified == False

### DIFF
--- a/scrapy_splash/cookies.py
+++ b/scrapy_splash/cookies.py
@@ -83,7 +83,7 @@ def har_to_cookie(har_cookie):
         value=har_cookie['value'],
         port=None,
         domain=har_cookie.get('domain', ''),
-        path=har_cookie.get('path', '/'),
+        path=har_cookie.get('path', ''),
         secure=har_cookie.get('secure', False),
         expires=expires_timestamp,
         discard=False,

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -18,3 +18,14 @@ def test_cookie_to_har():
     assert cookie_to_har(har_to_cookie(har_cookie)) == har_cookie
     cookie = har_to_cookie(har_cookie)
     assert vars(cookie) == vars(har_to_cookie(cookie_to_har(cookie)))
+
+
+def test_cookie_to_har_minimum_data():
+    har_cookie = {
+        "name": "TestCookie",
+        "value": "Cookie Value",
+        "secure": True,
+    }
+    assert cookie_to_har(har_to_cookie(har_cookie)) == har_cookie
+    cookie = har_to_cookie(har_cookie)
+    assert vars(cookie) == vars(har_to_cookie(cookie_to_har(cookie)))


### PR DESCRIPTION
@kmike I’m extremely unsure about this change, I have no idea of the side effects it may have.

I am trying to add test coverage to https://codecov.io/gh/scrapy-plugins/scrapy-splash/src/master/scrapy_splash/cookies.py#L111

This change adds such coverage, and ensures that `cookie_to_har(har_to_cookie(har_cookie)) == har_cookie` works if no path is specified.

On the other hand, setting ``/`` as a default path comes from Requests, where [it’s still used](https://github.com/psf/requests/blob/89ab030cdb83a728a30e172bc65d27ba214d2eda/requests/cookies.py#L453). Their implementation does have a difference that we lost when we simplified our code: they set `path='/'` if the `path` parameter is not received, but if `path=None` is received that `None` value is used instead; but I’m not sure if that is relevant to our use case, and it would not make `cookie_to_har(har_to_cookie(har_cookie)) == har_cookie` work either.