### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -417,6 +417,7 @@ Get HTML contents and a screenshot::
 
         # ...
             splash_args = {
+                'wait': 1,
                 'html': 1,
                 'png': 1,
                 'width': 600,


### PR DESCRIPTION
`[WARNING|middleware.py:418] Bad request to Splash: {'error': 400, 'type': 'BadOption', 'description': 'Incorrect HTTP API arguments', 'info': {'type': 'bad_argument', 'argument': 'render_all', 'description': "Pass non-zero 'wait' to render full webpage"}}`

if wait argument not passed, that error occured.

 