### PR TITLE
Fix/splash request fingerprint

### DIFF
--- a/scrapy_splash/dupefilter.py
+++ b/scrapy_splash/dupefilter.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from scrapy.dupefilters import RFPDupeFilter
 
 from scrapy.utils.url import canonicalize_url
-from scrapy.utils.request import request_fingerprint
+from scrapy.utils.request import fingerprint
 
 from .utils import dict_hash
 
@@ -17,7 +17,7 @@ from .utils import dict_hash
 def splash_request_fingerprint(request, include_headers=None):
     """ Request fingerprint which takes 'splash' meta key into account """
 
-    fp = request_fingerprint(request, include_headers=include_headers)
+    fp = fingerprint(request, include_headers=include_headers)
     if 'splash' not in request.meta:
         return fp
 
@@ -35,5 +35,5 @@ class SplashAwareDupeFilter(RFPDupeFilter):
     DupeFilter that takes 'splash' meta key in account.
     It should be used with SplashMiddleware.
     """
-    def request_fingerprint(self, request):
+    def fingerprint(self, request):
         return splash_request_fingerprint(request)

--- a/tests/test_fingerprints.py
+++ b/tests/test_fingerprints.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 
 import pytest
 import scrapy
-from scrapy.utils.request import request_fingerprint
+from scrapy.utils.request import fingerprint
 
 from scrapy_splash import SplashRequest
 from scrapy_splash.dupefilter import splash_request_fingerprint
@@ -48,9 +48,9 @@ def test_dict_hash_invalid():
 def test_request_fingerprint_nosplash():
     r1 = scrapy.Request("http://example.com")
     r2 = scrapy.Request("http://example.com", meta={"foo": "bar"})
-    assert request_fingerprint(r1) == splash_request_fingerprint(r1)
-    assert request_fingerprint(r1) == request_fingerprint(r2)
-    assert request_fingerprint(r1) == splash_request_fingerprint(r2)
+    assert fingerprint(r1) == splash_request_fingerprint(r1)
+    assert fingerprint(r1) == fingerprint(r2)
+    assert fingerprint(r1) == splash_request_fingerprint(r2)
 
 
 def assert_fingerprints_match(r1, r2):
@@ -68,7 +68,7 @@ def test_request_fingerprint_splash():
     r4 = scrapy.Request("http://example.com", meta={"foo": "bar", "splash": {"args": {"html": 1}}})
     r5 = scrapy.Request("http://example.com", meta={"splash": {"args": {"html": 1, "wait": 1.0}}})
 
-    assert request_fingerprint(r1) == request_fingerprint(r2)
+    assert fingerprint(r1) == fingerprint(r2)
     assert_fingerprints_dont_match(r1, r2)
     assert_fingerprints_dont_match(r1, r3)
     assert_fingerprints_dont_match(r1, r4)


### PR DESCRIPTION

This pull request includes changes to the `scrapy_splash` package to update the usage of the `request_fingerprint` function to the new `fingerprint` function from `scrapy.utils.request`. The changes affect both the main code and the test files.

Main code updates:

* [`scrapy_splash/dupefilter.py`](diffhunk://#diff-cb16bf9863b11240b3419640d6879aa90433961b320ee17f4bfa06c7fdc9faeaL12-R20): Replaced `request_fingerprint` with `fingerprint` in the `splash_request_fingerprint` function and the `SplashAwareDupeFilter` class.

Test updates:

* [`tests/test_fingerprints.py`](diffhunk://#diff-df18707a57851294a4b669b3b1acc4bc205dd4a2f7be58df6b67853cca505389L7-R7): Replaced `request_fingerprint` with `fingerprint` in the imports and updated all relevant test cases to use the new function.