### PR TITLE
Change url from required to optional parameter for SplashRequest

### DIFF
--- a/scrapy_splash/request.py
+++ b/scrapy_splash/request.py
@@ -31,7 +31,7 @@ class SplashRequest(scrapy.Request):
     It requires SplashMiddleware to work.
     """
     def __init__(self,
-                 url,
+                 url=None,
                  callback=None,
                  method='GET',
                  endpoint='render.html',
@@ -48,6 +48,8 @@ class SplashRequest(scrapy.Request):
                  meta=None,
                  **kwargs):
 
+        if url is None:
+            url = 'about:blank'
         url = to_unicode(url)
 
         meta = copy.deepcopy(meta) or {}

--- a/scrapy_splash/utils.py
+++ b/scrapy_splash/utils.py
@@ -5,12 +5,7 @@ import hashlib
 import six
 
 from scrapy.http import Headers
-import scrapy
-if scrapy.version_info >= (2, ):
-    from scrapy.utils.python import to_unicode
-else:
-    from scrapy.utils.python import to_native_str as to_unicode
-from scrapy.utils.python import to_bytes
+from scrapy.utils.python import to_unicode, to_bytes
 
 
 def dict_hash(obj, start=''):

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires=['scrapy', 'six'],
+    install_requires=['scrapy>=2.4', 'six'],
 )

--- a/tests/test_fingerprints.py
+++ b/tests/test_fingerprints.py
@@ -142,9 +142,9 @@ def requests():
         dict(url=url2, args={'wait': 0.5}),     # 5
         dict(url=url3),                         # 6
         dict(url=url2, method='POST'),          # 7
-        dict(url=url3, args={'wait': 0.5}),     # 8
-        dict(url=url3, args={'wait': 0.5}),     # 9
-        dict(url=url3, args={'wait': 0.7}),     # 10
+        dict(args={'wait': 0.5}),               # 8
+        dict(args={'wait': 0.5}),               # 9
+        dict(args={'wait': 0.7}),               # 10
         dict(url=url4),                         # 11
     ]
     splash_requests = [SplashRequest(**kwargs) for kwargs in request_kwargs]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -630,6 +630,21 @@ def test_cache_args():
     assert mw._remote_keys == {}
 
 
+def test_splash_request_no_url():
+    mw = _get_mw()
+    lua_source = "function main(splash) return {result='ok'} end"
+    req1 = SplashRequest(meta={'splash': {
+        'args': {'lua_source': lua_source},
+        'endpoint': 'execute',
+    }})
+    req = mw.process_request(req1, None)
+    assert req.url == 'http://127.0.0.1:8050/execute'
+    assert json.loads(to_unicode(req.body)) == {
+        'url': 'about:blank',
+        'lua_source': lua_source
+    }
+
+
 def test_post_request():
     mw = _get_mw()
     for body in [b'', b'foo=bar']:

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 passenv = SPLASH_URL
 deps =
     {[common]deps}
-    scrapy
+    scrapy >= 2.4.0
 commands =
     pip install -e .
     py.test --doctest-modules --doctest-glob '*.py,*.rst' --cov=scrapy_splash {posargs:README.rst scrapy_splash tests}

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 passenv = SPLASH_URL
 deps =
     {[common]deps}
-    scrapy >= 2.4.0
+    scrapy
 commands =
     pip install -e .
     py.test --doctest-modules --doctest-glob '*.py,*.rst' --cov=scrapy_splash {posargs:README.rst scrapy_splash tests}


### PR DESCRIPTION
This PR attempts to resolve #270 and resolve #271

Change `url` from ~optional to required~ required to optional parameter for `SplashRequest` by reverting this commit https://github.com/scrapy-plugins/scrapy-splash/commit/4154782b16c6248a5a9b8fe3ed0ebb1cbc600a60
Scrapy >= 2.4 set in ~tox.ini and~ `setup.py`
Removed code in `scrapy_splash/utils.py` to check if scrapy version is >= 2