### PR TITLE
Corrected the argument in super().__init__() within SplashAwareDupeFilter's __init__()

### DIFF
--- a/scrapy_splash/dupefilter.py
+++ b/scrapy_splash/dupefilter.py
@@ -136,7 +136,7 @@ class SplashAwareDupeFilter(RFPDupeFilter):
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__(path, debug, fingerprinter)
+        super().__init__(path, debug, fingerprinter=fingerprinter)
 
     def request_fingerprint(self, request):
         return splash_request_fingerprint(request)


### PR DESCRIPTION
Submitting this PR to resolve a bug highlighted here https://github.com/scrapy-plugins/scrapy-splash/pull/322#discussion_r1950182826. RFPDupeFilter's `__init__()` implements `fingerprinter` as a keyword-only argument.